### PR TITLE
respond with ErrUnauthorized on 401 from API

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
   schedule:
     - cron: '0 10 * * 3'
 

--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
   schedule:
     - cron: '0 10 * * 3'
 

--- a/client/client_suite_test.go
+++ b/client/client_suite_test.go
@@ -14,7 +14,7 @@ import (
 // fixture loads a JSON file from the fixtures folder and returns it as a string
 func fixture(path string) string {
 	const fixPath = "testdata/fixtures/"
-	b, err := ioutil.ReadFile(fixPath + path)
+	b, err := ioutil.ReadFile(fixPath + path) // #nosec
 	if err != nil {
 		panic(err)
 	}

--- a/client/error.go
+++ b/client/error.go
@@ -20,5 +20,8 @@ func (er ErrorResult) Error() string {
 	return fmt.Sprintf("%v %v", er.Err, er.Message)
 }
 
-// ErrNotFound is raised when the API returns a '404 Not Found' error.
+// ErrNotFound is returned when the API returns a '404 Not Found' error.
 var ErrNotFound = fmt.Errorf("entity not found")
+
+// ErrUnauthorized is returned when the API returns a '401 Unauthorized' error.
+var ErrUnauthorized = fmt.Errorf("unauthorized")

--- a/client/project.go
+++ b/client/project.go
@@ -76,13 +76,25 @@ func (c *RollbarApiClient) ListProjects() ([]Project, error) {
 		l.Err(err).Send()
 		return nil, err
 	}
-	if resp.StatusCode() != http.StatusOK {
-		errResp := resp.Error().(*ErrorResult)
-		l.Err(errResp).Send()
-		return nil, errResp
-	}
-	lpr := resp.Result().(*projectListResponse)
 
+	switch resp.StatusCode() {
+	case http.StatusUnauthorized:
+		l.Warn().Msg("Unauthorized")
+		return nil, ErrUnauthorized
+	case http.StatusOK:
+		l.Debug().Msg("Successfully listed projects")
+		break
+	default:
+		er := resp.Error().(*ErrorResult)
+		l.Error().
+			Int("StatusCode", resp.StatusCode()).
+			Str("Status", resp.Status()).
+			Interface("ErrorResult", er).
+			Msg("Error creating a project")
+		return nil, er
+	}
+
+	lpr := resp.Result().(*projectListResponse)
 	// FIXME: After deleting a project through the API, it still shows up in
 	//  the list of projects returned by the API - only with its name set to
 	//  nil. This seemingly undesirable behavior should be fixed on the API
@@ -116,7 +128,15 @@ func (c *RollbarApiClient) CreateProject(name string) (*Project, error) {
 		return nil, err
 	}
 
-	if resp.StatusCode() >= 400 {
+	switch resp.StatusCode() {
+	case http.StatusUnauthorized:
+		l.Warn().Msg("Unauthorized")
+		return nil, ErrUnauthorized
+	case http.StatusOK:
+		l.Debug().Msg("Project successfully created")
+		pr := resp.Result().(*projectResponse)
+		return &pr.Result, nil
+	default:
 		er := resp.Error().(*ErrorResult)
 		l.Error().
 			Int("StatusCode", resp.StatusCode()).
@@ -125,9 +145,6 @@ func (c *RollbarApiClient) CreateProject(name string) (*Project, error) {
 			Msg("Error creating a project")
 		return nil, er
 	}
-
-	pr := resp.Result().(*projectResponse)
-	return &pr.Result, nil
 }
 
 // ReadProject a Rollbar project from the API. If no matching project is found,
@@ -160,6 +177,9 @@ func (c *RollbarApiClient) ReadProject(projectId int) (*Project, error) {
 	case http.StatusNotFound:
 		l.Warn().Msg("Project not found")
 		return nil, ErrNotFound
+	case http.StatusUnauthorized:
+		l.Warn().Msg("Unauthorized")
+		return nil, ErrUnauthorized
 	default:
 		er := resp.Error().(*ErrorResult)
 		l.Error().
@@ -196,6 +216,9 @@ func (c *RollbarApiClient) DeleteProject(projectId int) error {
 	case http.StatusNotFound:
 		l.Warn().Msg("Project not found")
 		return ErrNotFound
+	case http.StatusUnauthorized:
+		l.Warn().Msg("Unauthorized")
+		return ErrUnauthorized
 	case http.StatusOK:
 		l.Debug().Msg("Project successfully deleted")
 		return nil

--- a/client/project.go
+++ b/client/project.go
@@ -16,7 +16,7 @@ import (
 
 // Project represents a Rollbar project.
 type Project struct {
-	Id           int    `model:"id" fake:"{number:1,1000000}""`
+	Id           int    `model:"id" fake:"{number:1,1000000}"`
 	Name         string `model:"name" fake:"{hackernoun}"`
 	AccountId    int    `json:"account_id" model:"account_id" fake:"{number:1,1000000}"`
 	DateCreated  int    `json:"date_created" model:"date_created" fake:"{number:1,1000000}"`

--- a/client/project.go
+++ b/client/project.go
@@ -83,7 +83,6 @@ func (c *RollbarApiClient) ListProjects() ([]Project, error) {
 		return nil, ErrUnauthorized
 	case http.StatusOK:
 		l.Debug().Msg("Successfully listed projects")
-		break
 	default:
 		er := resp.Error().(*ErrorResult)
 		l.Error().

--- a/client/project_access_tokens.go
+++ b/client/project_access_tokens.go
@@ -47,6 +47,9 @@ func (c *RollbarApiClient) ListProjectAccessTokens(projectID int) ([]ProjectAcce
 	case http.StatusNotFound:
 		l.Warn().Msg("Project not found")
 		return nil, ErrNotFound
+	case http.StatusUnauthorized:
+		l.Warn().Msg("Unauthorized")
+		return nil, ErrUnauthorized
 	default:
 		errResp := resp.Error().(*ErrorResult)
 		l.Err(errResp).Msg("Unexpected error")
@@ -119,7 +122,7 @@ func (c *RollbarApiClient) CreateProjectAccessToken(args ProjectAccessTokenArgs)
 	var pat ProjectAccessToken
 
 	// Sanity checks
-	if args.ProjectID == 0 {
+	if args.ProjectID <= 0 {
 		err := fmt.Errorf("project ID cannot be blank")
 		l.Err(err).Msg("Failed sanity check")
 		return pat, err
@@ -176,6 +179,9 @@ func (c *RollbarApiClient) CreateProjectAccessToken(args ProjectAccessTokenArgs)
 			Interface("token", pat).
 			Msg("Successfully created new project access token")
 		return pat, nil
+	case http.StatusUnauthorized:
+		l.Warn().Msg("Unauthorized")
+		return pat, ErrUnauthorized
 	default:
 		er := resp.Error().(*ErrorResult)
 		l.Error().
@@ -185,8 +191,6 @@ func (c *RollbarApiClient) CreateProjectAccessToken(args ProjectAccessTokenArgs)
 			Msg("Error creating project access token")
 		return pat, er
 	}
-
-	return pat, nil
 }
 
 /*

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -54,6 +54,13 @@ func (s *Suite) TestListProjects() {
 	httpmock.Reset()
 	_, err = s.client.ListProjects()
 	s.NotNil(err)
+
+	// Unauthorized
+	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
+		ErrorResult{Err: 401, Message: "Unauthorized"})
+	httpmock.RegisterResponder("GET", u, r)
+	_, err = s.client.ListProjects()
+	s.Equal(ErrUnauthorized, err)
 }
 
 func (s *Suite) TestCreateProject() {
@@ -88,6 +95,13 @@ func (s *Suite) TestCreateProject() {
 	httpmock.Reset()
 	_, err = s.client.CreateProject(name)
 	s.NotNil(err)
+
+	// Unauthorized
+	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
+		ErrorResult{Err: 401, Message: "Unauthorized"})
+	httpmock.RegisterResponder("POST", u, r)
+	_, err = s.client.CreateProject(name)
+	s.Equal(ErrUnauthorized, err)
 }
 
 func (s *Suite) TestReadProject() {
@@ -121,6 +135,13 @@ func (s *Suite) TestReadProject() {
 	httpmock.Reset()
 	_, err = s.client.ReadProject(expected.Id)
 	s.NotNil(err)
+
+	// Unauthorized
+	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
+		ErrorResult{Err: 401, Message: "Unauthorized"})
+	httpmock.RegisterResponder("GET", u, r)
+	_, err = s.client.ReadProject(expected.Id)
+	s.Equal(ErrUnauthorized, err)
 }
 
 func (s *Suite) TestDeleteProject() {
@@ -170,4 +191,11 @@ func (s *Suite) TestDeleteProject() {
 	httpmock.Reset()
 	err = s.client.DeleteProject(delId)
 	s.NotNil(err)
+
+	// Unauthorized
+	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
+		ErrorResult{Err: 401, Message: "Unauthorized"})
+	httpmock.RegisterResponder("DELETE", urlDel, r)
+	err = s.client.DeleteProject(delId)
+	s.Equal(ErrUnauthorized, err)
 }

--- a/client/team.go
+++ b/client/team.go
@@ -61,6 +61,9 @@ func (c *RollbarApiClient) CreateTeam(name string, level TeamAccessLevel) (Team,
 			Interface("team", t).
 			Msg("Successfully created new team")
 		return t, nil
+	case http.StatusUnauthorized:
+		l.Warn().Msg("Unauthorized")
+		return t, ErrUnauthorized
 	default:
 		er := resp.Error().(*ErrorResult)
 		l.Error().
@@ -74,6 +77,7 @@ func (c *RollbarApiClient) CreateTeam(name string, level TeamAccessLevel) (Team,
 
 // ListTeams lists all Rollbar teams.
 func (c *RollbarApiClient) ListTeams() ([]Team, error) {
+	log.Debug().Msg("Listing all teams")
 	var teams []Team
 	u := apiUrl + pathTeamList
 	resp, err := c.resty.R().
@@ -92,6 +96,9 @@ func (c *RollbarApiClient) ListTeams() ([]Team, error) {
 			Interface("teams", teams).
 			Msg("Successfully listed teams")
 		return teams, nil
+	case http.StatusUnauthorized:
+		log.Warn().Msg("Unauthorized")
+		return teams, ErrUnauthorized
 	default:
 		er := resp.Error().(*ErrorResult)
 		log.Error().
@@ -135,6 +142,9 @@ func (c *RollbarApiClient) ReadTeam(id int) (Team, error) {
 			Interface("team", t).
 			Msg("Successfully read team")
 		return t, nil
+	case http.StatusUnauthorized:
+		l.Warn().Msg("Unauthorized")
+		return t, ErrUnauthorized
 	default:
 		er := resp.Error().(*ErrorResult)
 		l.Error().
@@ -173,6 +183,9 @@ func (c *RollbarApiClient) DeleteTeam(id int) error {
 	case http.StatusOK:
 		l.Debug().Msg("Successfully deleted team")
 		return nil
+	case http.StatusUnauthorized:
+		l.Warn().Msg("Unauthorized")
+		return ErrUnauthorized
 	default:
 		er := resp.Error().(*ErrorResult)
 		l.Error().

--- a/client/team_test.go
+++ b/client/team_test.go
@@ -55,6 +55,13 @@ func (s *Suite) TestCreateTeam() {
 	httpmock.Reset()
 	_, err = s.client.CreateTeam(teamName, TeamAccessStandard)
 	s.NotNil(err)
+
+	// Unauthorized
+	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
+		ErrorResult{Err: 401, Message: "Unauthorized"})
+	httpmock.RegisterResponder("POST", u, r)
+	_, err = s.client.CreateTeam(teamName, TeamAccessStandard)
+	s.Equal(ErrUnauthorized, err)
 }
 
 func (s *Suite) TestListTeams() {
@@ -100,6 +107,13 @@ func (s *Suite) TestListTeams() {
 	httpmock.Reset()
 	_, err = s.client.ListTeams()
 	s.NotNil(err)
+
+	// Unauthorized
+	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
+		ErrorResult{Err: 401, Message: "Unauthorized"})
+	httpmock.RegisterResponder("GET", u, r)
+	_, err = s.client.ListTeams()
+	s.Equal(ErrUnauthorized, err)
 }
 
 func (s *Suite) TestReadTeam() {
@@ -137,6 +151,13 @@ func (s *Suite) TestReadTeam() {
 	httpmock.Reset()
 	_, err = s.client.ReadTeam(teamId)
 	s.NotNil(err)
+
+	// Unauthorized
+	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
+		ErrorResult{Err: 401, Message: "Unauthorized"})
+	httpmock.RegisterResponder("GET", u, r)
+	_, err = s.client.ReadTeam(teamId)
+	s.Equal(ErrUnauthorized, err)
 }
 
 func (s *Suite) TestDeleteTeam() {
@@ -167,6 +188,13 @@ func (s *Suite) TestDeleteTeam() {
 	httpmock.Reset()
 	err = s.client.DeleteTeam(teamId)
 	s.NotNil(err)
+
+	// Unauthorized
+	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
+		ErrorResult{Err: 401, Message: "Unauthorized"})
+	httpmock.RegisterResponder("DELETE", u, r)
+	err = s.client.DeleteTeam(teamId)
+	s.Equal(ErrUnauthorized, err)
 }
 
 /*


### PR DESCRIPTION
Per #14 this PR adds support for `ErrUnauthorized` to the Rollbar API client sub-package.