### PR TITLE
Testify acceptance tests

### DIFF
--- a/rollbar/data_source_project_access_tokens_test.go
+++ b/rollbar/data_source_project_access_tokens_test.go
@@ -17,7 +17,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: s.testAccRollbarProjectAccessTokensDataSourceConfig(""),
+				Config: s.configDataSourceProjectAccessTokens(""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "project_id"),
 					testAccCheckProjectAccessTokensDataSourceExists(rn),
@@ -36,7 +36,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: s.testAccRollbarProjectAccessTokensDataSourceConfig("post"),
+				Config: s.configDataSourceProjectAccessTokens("post"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "project_id"),
 					testAccCheckProjectAccessTokensDataSourceExists(rn),
@@ -50,16 +50,16 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 	})
 }
 
-// testAccRollbarProjectAccessTokensDataSourceConfig generates Terraform
+// configDataSourceProjectAccessTokens generates Terraform
 // configuration for resource `rollbar_project_access_tokens`. If `prefix` is
 // not empty, it will be supplied as the `prefix` argument to the data source.
-func (s *Suite) testAccRollbarProjectAccessTokensDataSourceConfig(prefix string) string {
+func (s *Suite) configDataSourceProjectAccessTokens(prefix string) string {
 	var configPrefix string
 	if prefix != "" {
 		configPrefix = fmt.Sprintf(`prefix = "%s"`, prefix)
 	}
-	// language=terraform
-	return fmt.Sprintf(`
+	// language=hcl
+	tmpl := `
 		resource "rollbar_project" "test" {
 		  name         = "%s"
 		}
@@ -69,7 +69,8 @@ func (s *Suite) testAccRollbarProjectAccessTokensDataSourceConfig(prefix string)
 			depends_on = [rollbar_project.test]
 			%s
 		}
-	`, s.projectName, configPrefix)
+	`
+	return fmt.Sprintf(tmpl, s.projectName, configPrefix)
 }
 
 // testAccCheckProjectAccessTokensDataSourceExists checks that the data source's

--- a/rollbar/data_source_project_access_tokens_test.go
+++ b/rollbar/data_source_project_access_tokens_test.go
@@ -2,7 +2,6 @@ package rollbar_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -10,10 +9,7 @@ import (
 // TestAccRollbarProjectAccessTokensDataSource tests reading project access
 // tokens with `rollbar_project_access_tokens` data source.
 func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
-
 	rn := "data.rollbar_project_access_tokens.test"
-	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
 	resource.Test(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
@@ -21,7 +17,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRollbarProjectAccessTokensDataSourceConfig(name, ""),
+				Config: s.testAccRollbarProjectAccessTokensDataSourceConfig(""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "project_id"),
 					testAccCheckProjectAccessTokensDataSourceExists(rn),
@@ -40,7 +36,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRollbarProjectAccessTokensDataSourceConfig(name, "post"),
+				Config: s.testAccRollbarProjectAccessTokensDataSourceConfig("post"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "project_id"),
 					testAccCheckProjectAccessTokensDataSourceExists(rn),
@@ -57,7 +53,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 // testAccRollbarProjectAccessTokensDataSourceConfig generates Terraform
 // configuration for resource `rollbar_project_access_tokens`. If `prefix` is
 // not empty, it will be supplied as the `prefix` argument to the data source.
-func testAccRollbarProjectAccessTokensDataSourceConfig(projName string, prefix string) string {
+func (s *Suite) testAccRollbarProjectAccessTokensDataSourceConfig(prefix string) string {
 	var configPrefix string
 	if prefix != "" {
 		configPrefix = fmt.Sprintf(`prefix = "%s"`, prefix)
@@ -73,7 +69,7 @@ func testAccRollbarProjectAccessTokensDataSourceConfig(projName string, prefix s
 			depends_on = [rollbar_project.test]
 			%s
 		}
-	`, projName, configPrefix)
+	`, s.projectName, configPrefix)
 }
 
 // testAccCheckProjectAccessTokensDataSourceExists checks that the data source's

--- a/rollbar/data_source_project_access_tokens_test.go
+++ b/rollbar/data_source_project_access_tokens_test.go
@@ -1,24 +1,23 @@
-package rollbar
+package rollbar_test
 
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"testing"
 )
 
 // TestAccRollbarProjectAccessTokensDataSource tests reading project access
 // tokens with `rollbar_project_access_tokens` data source.
-func TestAccRollbarProjectAccessTokensDataSource(t *testing.T) {
+func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 
 	rn := "data.rollbar_project_access_tokens.test"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+	resource.Test(s.T(), resource.TestCase{
+		PreCheck:     func() { s.preCheck() },
+		Providers:    s.providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
@@ -35,9 +34,9 @@ func TestAccRollbarProjectAccessTokensDataSource(t *testing.T) {
 		},
 	})
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+	resource.Test(s.T(), resource.TestCase{
+		PreCheck:     func() { s.preCheck() },
+		Providers:    s.providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{

--- a/rollbar/data_source_project_access_tokens_test.go
+++ b/rollbar/data_source_project_access_tokens_test.go
@@ -16,7 +16,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: s.configDataSourceProjectAccessTokens(""),
+				Config: s.configDataSourceRollbarProjectAccessTokens(""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "project_id"),
 					s.checkResourceStateSanity(rn),
@@ -35,7 +35,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: s.configDataSourceProjectAccessTokens("post"),
+				Config: s.configDataSourceRollbarProjectAccessTokens("post"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "project_id"),
 					s.checkResourceStateSanity(rn),
@@ -49,10 +49,10 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 	})
 }
 
-// configDataSourceProjectAccessTokens generates Terraform
-// configuration for resource `rollbar_project_access_tokens`. If `prefix` is
-// not empty, it will be supplied as the `prefix` argument to the data source.
-func (s *Suite) configDataSourceProjectAccessTokens(prefix string) string {
+// configDataSourceRollbarProjectAccessTokens generates Terraform configuration
+// for resource `rollbar_project_access_tokens`. If `prefix` is not empty, it
+// will be supplied as the `prefix` argument to the data source.
+func (s *Suite) configDataSourceRollbarProjectAccessTokens(prefix string) string {
 	var configPrefix string
 	if prefix != "" {
 		configPrefix = fmt.Sprintf(`prefix = "%s"`, prefix)

--- a/rollbar/data_source_project_access_tokens_test.go
+++ b/rollbar/data_source_project_access_tokens_test.go
@@ -3,7 +3,6 @@ package rollbar_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // TestAccRollbarProjectAccessTokensDataSource tests reading project access
@@ -20,7 +19,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 				Config: s.configDataSourceProjectAccessTokens(""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "project_id"),
-					testAccCheckProjectAccessTokensDataSourceExists(rn),
+					s.checkResourceStateSanity(rn),
 
 					// By default Rollbar provisions a new project with 4 access
 					// tokens.
@@ -39,7 +38,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 				Config: s.configDataSourceProjectAccessTokens("post"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "project_id"),
-					testAccCheckProjectAccessTokensDataSourceExists(rn),
+					s.checkResourceStateSanity(rn),
 
 					// By default Rollbar provisions a new project with 4 access
 					// tokens, 2 of whose names beging with "post".
@@ -71,22 +70,4 @@ func (s *Suite) configDataSourceProjectAccessTokens(prefix string) string {
 		}
 	`
 	return fmt.Sprintf(tmpl, s.projectName, configPrefix)
-}
-
-// testAccCheckProjectAccessTokensDataSourceExists checks that the data source's
-// ID is set in Terraform state.
-// FIXME: This is repeated all over the place.  We need a DRY solution
-func testAccCheckProjectAccessTokensDataSourceExists(rn string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[rn]
-		if !ok {
-			return fmt.Errorf("can't find project access tokens data source: %s", rn)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("project access tokens data source ID not set")
-		}
-
-		return nil
-	}
 }

--- a/rollbar/data_source_project_test.go
+++ b/rollbar/data_source_project_test.go
@@ -2,17 +2,13 @@ package rollbar_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // TestAccRollbarProjectDataSource tests reading a project with
 // `rollbar_project` data source.
 func (s *Suite) TestAccRollbarProjectDataSource() {
-
 	rn := "data.rollbar_project.test"
-	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
 	resource.Test(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
@@ -20,9 +16,9 @@ func (s *Suite) TestAccRollbarProjectDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRollbarProjectDataSourceConfig(name),
+				Config: s.testAccRollbarProjectDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(rn, "name", name),
+					resource.TestCheckResourceAttr(rn, "name", s.projectName),
 					resource.TestCheckResourceAttrSet(rn, "id"),
 					resource.TestCheckResourceAttrSet(rn, "account_id"),
 					resource.TestCheckResourceAttrSet(rn, "date_created"),
@@ -32,7 +28,7 @@ func (s *Suite) TestAccRollbarProjectDataSource() {
 	})
 }
 
-func testAccRollbarProjectDataSourceConfig(projName string) string {
+func (s *Suite) testAccRollbarProjectDataSourceConfig() string {
 	return fmt.Sprintf(`
 		resource "rollbar_project" "test" {
 		  name         = "%s"
@@ -42,5 +38,5 @@ func testAccRollbarProjectDataSourceConfig(projName string) string {
 			name = "%s"
 			depends_on = [rollbar_project.test]
 		}
-	`, projName, projName)
+	`, s.projectName, s.projectName)
 }

--- a/rollbar/data_source_project_test.go
+++ b/rollbar/data_source_project_test.go
@@ -16,7 +16,7 @@ func (s *Suite) TestAccRollbarProjectDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: s.testAccRollbarProjectDataSourceConfig(),
+				Config: s.configDataSourceRollbarProject(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rn, "name", s.projectName),
 					resource.TestCheckResourceAttrSet(rn, "id"),
@@ -28,7 +28,7 @@ func (s *Suite) TestAccRollbarProjectDataSource() {
 	})
 }
 
-func (s *Suite) testAccRollbarProjectDataSourceConfig() string {
+func (s *Suite) configDataSourceRollbarProject() string {
 	return fmt.Sprintf(`
 		resource "rollbar_project" "test" {
 		  name         = "%s"

--- a/rollbar/data_source_project_test.go
+++ b/rollbar/data_source_project_test.go
@@ -1,23 +1,22 @@
-package rollbar
+package rollbar_test
 
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"testing"
 )
 
 // TestAccRollbarProjectDataSource tests reading a project with
 // `rollbar_project` data source.
-func TestAccRollbarProjectDataSource(t *testing.T) {
+func (s *Suite) TestAccRollbarProjectDataSource() {
 
 	rn := "data.rollbar_project.test"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+	resource.Test(s.T(), resource.TestCase{
+		PreCheck:     func() { s.preCheck() },
+		Providers:    s.providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{

--- a/rollbar/data_source_project_test.go
+++ b/rollbar/data_source_project_test.go
@@ -29,7 +29,8 @@ func (s *Suite) TestAccRollbarProjectDataSource() {
 }
 
 func (s *Suite) configDataSourceRollbarProject() string {
-	return fmt.Sprintf(`
+	// language=hcl
+	tmpl := `
 		resource "rollbar_project" "test" {
 		  name         = "%s"
 		}
@@ -38,5 +39,6 @@ func (s *Suite) configDataSourceRollbarProject() string {
 			name = "%s"
 			depends_on = [rollbar_project.test]
 		}
-	`, s.projectName, s.projectName)
+	`
+	return fmt.Sprintf(tmpl, s.projectName, s.projectName)
 }

--- a/rollbar/data_source_projects_test.go
+++ b/rollbar/data_source_projects_test.go
@@ -2,17 +2,13 @@ package rollbar_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // TestAccRollbarProjectsDataSource tests listing of all projects with
 // `rollbar_projects` data source.
 func (s *Suite) TestAccRollbarProjectsDataSource() {
-
 	rn := "data.rollbar_projects.all"
-	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
 	resource.Test(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
@@ -20,18 +16,18 @@ func (s *Suite) TestAccRollbarProjectsDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRollbarProjectsDataSourceConfig(name),
+				Config: s.testAccRollbarProjectsDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "projects.#"),
 					resource.TestCheckResourceAttr(rn, "projects.#", "1"),
-					resource.TestCheckResourceAttr(rn, "projects.0.name", name),
+					resource.TestCheckResourceAttr(rn, "projects.0.name", s.projectName),
 				),
 			},
 		},
 	})
 }
 
-func testAccRollbarProjectsDataSourceConfig(projName string) string {
+func (s *Suite) testAccRollbarProjectsDataSourceConfig() string {
 	return fmt.Sprintf(`
 		resource "rollbar_project" "test" {
 		  name         = "%s"
@@ -40,5 +36,5 @@ func testAccRollbarProjectsDataSourceConfig(projName string) string {
 		data "rollbar_projects" "all" {
 			depends_on = [rollbar_project.test]
 		}
-	`, projName)
+	`, s.projectName)
 }

--- a/rollbar/data_source_projects_test.go
+++ b/rollbar/data_source_projects_test.go
@@ -1,23 +1,22 @@
-package rollbar
+package rollbar_test
 
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"testing"
 )
 
 // TestAccRollbarProjectsDataSource tests listing of all projects with
 // `rollbar_projects` data source.
-func TestAccRollbarProjectsDataSource(t *testing.T) {
+func (s *Suite) TestAccRollbarProjectsDataSource() {
 
 	rn := "data.rollbar_projects.all"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+	resource.Test(s.T(), resource.TestCase{
+		PreCheck:     func() { s.preCheck() },
+		Providers:    s.providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{

--- a/rollbar/data_source_projects_test.go
+++ b/rollbar/data_source_projects_test.go
@@ -28,7 +28,8 @@ func (s *Suite) TestAccRollbarProjectsDataSource() {
 }
 
 func (s *Suite) configDataSourceRollbarProjects() string {
-	return fmt.Sprintf(`
+	// language=hcl
+	tmpl := `
 		resource "rollbar_project" "test" {
 		  name         = "%s"
 		}
@@ -36,5 +37,6 @@ func (s *Suite) configDataSourceRollbarProjects() string {
 		data "rollbar_projects" "all" {
 			depends_on = [rollbar_project.test]
 		}
-	`, s.projectName)
+	`
+	return fmt.Sprintf(tmpl, s.projectName)
 }

--- a/rollbar/data_source_projects_test.go
+++ b/rollbar/data_source_projects_test.go
@@ -16,7 +16,7 @@ func (s *Suite) TestAccRollbarProjectsDataSource() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: s.testAccRollbarProjectsDataSourceConfig(),
+				Config: s.configDataSourceRollbarProjects(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "projects.#"),
 					resource.TestCheckResourceAttr(rn, "projects.#", "1"),
@@ -27,7 +27,7 @@ func (s *Suite) TestAccRollbarProjectsDataSource() {
 	})
 }
 
-func (s *Suite) testAccRollbarProjectsDataSourceConfig() string {
+func (s *Suite) configDataSourceRollbarProjects() string {
 	return fmt.Sprintf(`
 		resource "rollbar_project" "test" {
 		  name         = "%s"

--- a/rollbar/provider_test.go
+++ b/rollbar/provider_test.go
@@ -11,7 +11,9 @@ package rollbar_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/rollbar/terraform-provider-rollbar/rollbar"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -62,4 +64,21 @@ func (s *Suite) SetupTest() {
 
 func TestSuite(t *testing.T) {
 	suite.Run(t, new(Suite))
+}
+
+// checkResourceStateSanity checks that the resource is present in the Terraform
+// state, and that its ID is set.
+func (s *Suite) checkResourceStateSanity(rn string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("can't find resource: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID not set")
+		}
+
+		return nil
+	}
 }

--- a/rollbar/provider_test.go
+++ b/rollbar/provider_test.go
@@ -6,22 +6,27 @@
  * between author and licensee.
  */
 
-package rollbar
+package rollbar_test
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/rollbar/terraform-provider-rollbar/rollbar"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/suite"
 	"os"
 	"testing"
 )
 
-var testAccProviders map[string]*schema.Provider
-var testAccProviderFactories func(providers *[]*schema.Provider) map[string]func() (*schema.Provider, error)
-var testAccProvider *schema.Provider
-var testAccProviderFunc func() *schema.Provider
+// AcceptanceSuite is the acceptance testing suite.
+type AcceptanceSuite struct {
+	suite.Suite
+	provider     *schema.Provider
+	providers    map[string]*schema.Provider
+	providerFunc func() *schema.Provider
+}
 
-func init() {
+func (s *AcceptanceSuite) SetupSuite() {
 	// Log to console
 	log.Logger = log.
 		With().Caller().
@@ -33,34 +38,20 @@ func init() {
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
 	// Setup testing
-	testAccProvider = Provider()
-	testAccProviders = map[string]*schema.Provider{
-		"rollbar": testAccProvider,
+	s.provider = rollbar.Provider()
+	s.providers = map[string]*schema.Provider{
+		"rollbar": s.provider,
 	}
-
-	// FIXME: Implement this for use with resource.TestCase.ProviderFactories, as the simpler
-	//  resource.TestCase.Providers is deprecated.
-	/*
-		testAccProviderFactories = func(providers *[]*schema.Provider) map[string]func() (*schema.Provider, error) {
-			// this is an SDKV2 compatible hack, the "factory" functions are
-			// effectively singletons for the lifecycle of a resource.Test
-			var providerNames = []string{"aws", "awseast", "awswest", "awsalternate", "awsus-east-1", "awsalternateaccountalternateregion", "awsalternateaccountsameregion", "awssameaccountalternateregion", "awsthird"}
-			var factories = make(map[string]func() (*schema.Provider, error), len(providerNames))
-			for _, name := range providerNames {
-				p := Provider()
-				factories[name] = func() (*schema.Provider, error) { //nolint:unparam
-					return p, nil
-				}
-				*providers = append(*providers, p)
-			}
-			return factories
-		}
-	*/
-	testAccProviderFunc = func() *schema.Provider { return testAccProvider }
+	s.providerFunc = func() *schema.Provider { return s.provider }
 }
-func testAccPreCheck(t *testing.T) {
-	if token := os.Getenv("ROLLBAR_TOKEN"); token == "" {
-		t.Fatal("ROLLBAR_TOKEN must be set for acceptance tests")
-	}
+
+// preCheck ensures we are ready to run the test
+func (s *AcceptanceSuite) preCheck() {
+	token := os.Getenv("ROLLBAR_TOKEN")
+	s.NotEmpty(token, "ROLLBAR_TOKEN must be set for acceptance tests")
 	log.Debug().Msg("Passed preflight check")
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(AcceptanceSuite))
 }

--- a/rollbar/provider_test.go
+++ b/rollbar/provider_test.go
@@ -21,9 +21,8 @@ import (
 // Suite is the acceptance testing suite.
 type Suite struct {
 	suite.Suite
-	provider     *schema.Provider
-	providers    map[string]*schema.Provider
-	providerFunc func() *schema.Provider
+	provider  *schema.Provider
+	providers map[string]*schema.Provider
 }
 
 func (s *Suite) SetupSuite() {
@@ -42,7 +41,6 @@ func (s *Suite) SetupSuite() {
 	s.providers = map[string]*schema.Provider{
 		"rollbar": s.provider,
 	}
-	s.providerFunc = func() *schema.Provider { return s.provider }
 }
 
 // preCheck ensures we are ready to run the test

--- a/rollbar/provider_test.go
+++ b/rollbar/provider_test.go
@@ -9,6 +9,8 @@
 package rollbar_test
 
 import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rollbar/terraform-provider-rollbar/rollbar"
 	"github.com/rs/zerolog"
@@ -23,6 +25,9 @@ type Suite struct {
 	suite.Suite
 	provider  *schema.Provider
 	providers map[string]*schema.Provider
+
+	// The following variables are populated before each test by SetupTest():
+	projectName string // Name of a Rollbar project
 }
 
 func (s *Suite) SetupSuite() {
@@ -48,6 +53,11 @@ func (s *Suite) preCheck() {
 	token := os.Getenv("ROLLBAR_TOKEN")
 	s.NotEmpty(token, "ROLLBAR_TOKEN must be set for acceptance tests")
 	log.Debug().Msg("Passed preflight check")
+}
+
+func (s *Suite) SetupTest() {
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	s.projectName = fmt.Sprintf("tf-acc-test-%s", randString)
 }
 
 func TestSuite(t *testing.T) {

--- a/rollbar/provider_test.go
+++ b/rollbar/provider_test.go
@@ -18,15 +18,15 @@ import (
 	"testing"
 )
 
-// AcceptanceSuite is the acceptance testing suite.
-type AcceptanceSuite struct {
+// Suite is the acceptance testing suite.
+type Suite struct {
 	suite.Suite
 	provider     *schema.Provider
 	providers    map[string]*schema.Provider
 	providerFunc func() *schema.Provider
 }
 
-func (s *AcceptanceSuite) SetupSuite() {
+func (s *Suite) SetupSuite() {
 	// Log to console
 	log.Logger = log.
 		With().Caller().
@@ -46,12 +46,12 @@ func (s *AcceptanceSuite) SetupSuite() {
 }
 
 // preCheck ensures we are ready to run the test
-func (s *AcceptanceSuite) preCheck() {
+func (s *Suite) preCheck() {
 	token := os.Getenv("ROLLBAR_TOKEN")
 	s.NotEmpty(token, "ROLLBAR_TOKEN must be set for acceptance tests")
 	log.Debug().Msg("Passed preflight check")
 }
 
 func TestSuite(t *testing.T) {
-	suite.Run(t, new(AcceptanceSuite))
+	suite.Run(t, new(Suite))
 }

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -40,11 +40,13 @@ func (s *Suite) TestAccRollbarProject() {
 }
 
 func (s *Suite) configResourceRollbarProject() string {
-	return fmt.Sprintf(`
+	// language=hcl
+	tmpl := `
 		resource "rollbar_project" "foo" {
 		  name         = "%s"
 		}
-	`, s.projectName)
+	`
+	return fmt.Sprintf(tmpl, s.projectName)
 }
 
 // checkRollbarProjectExists tests that the newly created project exists

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -27,19 +27,19 @@ func (s *Suite) TestAccRollbarProject() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: s.testAccRollbarProjectConfig(),
+				Config: s.configResourceRollbarProject(),
 				Check: resource.ComposeTestCheckFunc(
 					s.checkResourceStateSanity(rn),
 					resource.TestCheckResourceAttr(rn, "name", s.projectName),
-					s.testAccRollbarProjectExists(rn, s.projectName),
-					s.testAccRollbarProjectInProjectList(rn),
+					s.checkRollbarProjectExists(rn, s.projectName),
+					s.checkRollbarProjectInProjectList(rn),
 				),
 			},
 		},
 	})
 }
 
-func (s *Suite) testAccRollbarProjectConfig() string {
+func (s *Suite) configResourceRollbarProject() string {
 	return fmt.Sprintf(`
 		resource "rollbar_project" "foo" {
 		  name         = "%s"
@@ -47,8 +47,8 @@ func (s *Suite) testAccRollbarProjectConfig() string {
 	`, s.projectName)
 }
 
-// testAccRollbarProjectExists tests that the newly created project exists
-func (s *Suite) testAccRollbarProjectExists(rn string, name string) resource.TestCheckFunc {
+// checkRollbarProjectExists tests that the newly created project exists
+func (s *Suite) checkRollbarProjectExists(rn string, name string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
 		id, err := s.getResourceIDInt(ts, rn)
 		if err != nil {
@@ -66,9 +66,9 @@ func (s *Suite) testAccRollbarProjectExists(rn string, name string) resource.Tes
 	}
 }
 
-// testAccRollbarProjectInProjectList tests that the newly created project is
+// checkRollbarProjectInProjectList tests that the newly created project is
 // present in the list of all projects.
-func (s *Suite) testAccRollbarProjectInProjectList(rn string) resource.TestCheckFunc {
+func (s *Suite) checkRollbarProjectInProjectList(rn string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
 		id, err := s.getResourceIDInt(ts, rn)
 		if err != nil {

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -6,7 +6,7 @@
  * between author and licensee.
  */
 
-package rollbar
+package rollbar_test
 
 import (
 	"fmt"
@@ -16,34 +16,34 @@ import (
 	"github.com/rollbar/terraform-provider-rollbar/client"
 	"github.com/rs/zerolog/log"
 	"strconv"
-	"testing"
 )
 
 // TestAccRollbarProject tests creation and deletion of a Rollbar project.
-func TestAccRollbarProject(t *testing.T) {
+func (s *Suite) TestAccRollbarProject() {
 
 	rn := "rollbar_project.foo"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
+	resource.Test(s.T(), resource.TestCase{
+		PreCheck: func() { s.preCheck() },
 		//ProviderFactories: testAccProviderFactories(),
-		Providers:    testAccProviders,
+		Providers:    s.providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRollbarProjectConfig(randString),
+				Config: s.testAccRollbarProjectConfig(randString),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rn, "name", name),
-					testAccRollbarProjectExists(rn, name),
-					testAccRollbarProjectInProjectList(rn),
+					s.testAccRollbarProjectExists(rn, name),
+					s.testAccRollbarProjectInProjectList(rn),
 				),
 			},
 		},
 	})
 }
-func testAccRollbarProjectConfig(randString string) string {
+
+func (s *Suite) testAccRollbarProjectConfig(randString string) string {
 	return fmt.Sprintf(`
 		resource "rollbar_project" "foo" {
 		  name         = "tf-acc-test-%s"
@@ -52,10 +52,10 @@ func testAccRollbarProjectConfig(randString string) string {
 }
 
 // testAccRollbarProjectExists tests that the newly created project exists
-func testAccRollbarProjectExists(rn string, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+func (s *Suite) testAccRollbarProjectExists(rn string, name string) resource.TestCheckFunc {
+	return func(ts *terraform.State) error {
 		// Check terraform config is sane
-		rs, ok := s.RootModule().Resources[rn]
+		rs, ok := ts.RootModule().Resources[rn]
 		if !ok {
 			return fmt.Errorf("Not Found: %s", rn)
 		}
@@ -69,7 +69,7 @@ func testAccRollbarProjectExists(rn string, name string) resource.TestCheckFunc 
 		}
 
 		// Check that project exists
-		c := testAccProvider.Meta().(*client.RollbarApiClient)
+		c := s.provider.Meta().(*client.RollbarApiClient)
 		proj, err := c.ReadProject(id)
 		if err != nil {
 			return err
@@ -85,10 +85,10 @@ func testAccRollbarProjectExists(rn string, name string) resource.TestCheckFunc 
 
 // testAccRollbarProjectInProjectList tests that the newly created project is
 // present in the list of all projects.
-func testAccRollbarProjectInProjectList(rn string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
+func (s *Suite) testAccRollbarProjectInProjectList(rn string) resource.TestCheckFunc {
+	return func(ts *terraform.State) error {
 		// Check terraform config is sane
-		rs, ok := s.RootModule().Resources[rn]
+		rs, ok := ts.RootModule().Resources[rn]
 		if !ok {
 			return fmt.Errorf("Not Found: %s", rn)
 		}
@@ -102,7 +102,7 @@ func testAccRollbarProjectInProjectList(rn string) resource.TestCheckFunc {
 		}
 
 		// Check that project exists
-		c := testAccProvider.Meta().(*client.RollbarApiClient)
+		c := s.provider.Meta().(*client.RollbarApiClient)
 		projList, err := c.ListProjects()
 		if err != nil {
 			return err

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/rollbar/terraform-provider-rollbar/client"
 	"github.com/rs/zerolog/log"
-	"strconv"
 )
 
 // TestAccRollbarProject tests creation and deletion of a Rollbar project.
@@ -51,21 +50,10 @@ func (s *Suite) testAccRollbarProjectConfig() string {
 // testAccRollbarProjectExists tests that the newly created project exists
 func (s *Suite) testAccRollbarProjectExists(rn string, name string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
-		// Check terraform config is sane
-		rs, ok := ts.RootModule().Resources[rn]
-		if !ok {
-			return fmt.Errorf("Not Found: %s", rn)
-		}
-		idString := rs.Primary.ID
-		if idString == "" {
-			return fmt.Errorf("No project ID is set")
-		}
-		id, err := strconv.Atoi(idString)
+		id, err := s.getResourceIDInt(ts, rn)
 		if err != nil {
 			return err
 		}
-
-		// Check that project exists
 		c := s.provider.Meta().(*client.RollbarApiClient)
 		proj, err := c.ReadProject(id)
 		if err != nil {
@@ -74,8 +62,6 @@ func (s *Suite) testAccRollbarProjectExists(rn string, name string) resource.Tes
 		if proj.Name != name {
 			return fmt.Errorf("project name from API does not match project name in Terraform config")
 		}
-
-		// Success
 		return nil
 	}
 }
@@ -84,21 +70,10 @@ func (s *Suite) testAccRollbarProjectExists(rn string, name string) resource.Tes
 // present in the list of all projects.
 func (s *Suite) testAccRollbarProjectInProjectList(rn string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
-		// Check terraform config is sane
-		rs, ok := ts.RootModule().Resources[rn]
-		if !ok {
-			return fmt.Errorf("Not Found: %s", rn)
-		}
-		idString := rs.Primary.ID
-		if idString == "" {
-			return fmt.Errorf("No project ID is set")
-		}
-		id, err := strconv.Atoi(idString)
+		id, err := s.getResourceIDInt(ts, rn)
 		if err != nil {
 			return err
 		}
-
-		// Check that project exists
 		c := s.provider.Meta().(*client.RollbarApiClient)
 		projList, err := c.ListProjects()
 		if err != nil {
@@ -115,8 +90,6 @@ func (s *Suite) testAccRollbarProjectInProjectList(rn string) resource.TestCheck
 			log.Debug().Int("id", id).Msg(msg)
 			return fmt.Errorf(msg)
 		}
-
-		// Success
 		return nil
 	}
 }

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -10,7 +10,6 @@ package rollbar_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/rollbar/terraform-provider-rollbar/client"
@@ -20,10 +19,7 @@ import (
 
 // TestAccRollbarProject tests creation and deletion of a Rollbar project.
 func (s *Suite) TestAccRollbarProject() {
-
 	rn := "rollbar_project.foo"
-	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	name := fmt.Sprintf("tf-acc-test-%s", randString)
 
 	resource.Test(s.T(), resource.TestCase{
 		PreCheck: func() { s.preCheck() },
@@ -32,10 +28,10 @@ func (s *Suite) TestAccRollbarProject() {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: s.testAccRollbarProjectConfig(randString),
+				Config: s.testAccRollbarProjectConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(rn, "name", name),
-					s.testAccRollbarProjectExists(rn, name),
+					resource.TestCheckResourceAttr(rn, "name", s.projectName),
+					s.testAccRollbarProjectExists(rn, s.projectName),
 					s.testAccRollbarProjectInProjectList(rn),
 				),
 			},
@@ -43,12 +39,12 @@ func (s *Suite) TestAccRollbarProject() {
 	})
 }
 
-func (s *Suite) testAccRollbarProjectConfig(randString string) string {
+func (s *Suite) testAccRollbarProjectConfig() string {
 	return fmt.Sprintf(`
 		resource "rollbar_project" "foo" {
-		  name         = "tf-acc-test-%s"
+		  name         = "%s"
 		}
-	`, randString)
+	`, s.projectName)
 }
 
 // testAccRollbarProjectExists tests that the newly created project exists

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -30,6 +30,7 @@ func (s *Suite) TestAccRollbarProject() {
 			{
 				Config: s.testAccRollbarProjectConfig(),
 				Check: resource.ComposeTestCheckFunc(
+					s.checkResourceStateSanity(rn),
 					resource.TestCheckResourceAttr(rn, "name", s.projectName),
 					s.testAccRollbarProjectExists(rn, s.projectName),
 					s.testAccRollbarProjectInProjectList(rn),


### PR DESCRIPTION
This PR closes #33 by migrating the acceptance tests to use [Testify](https://github.com/stretchr/testify/) library.  It also improves the DRYness of the test suite.