### PR TITLE
no longer depends on zero pre-existing projects

### DIFF
--- a/rollbar/data_source_project_access_tokens_test.go
+++ b/rollbar/data_source_project_access_tokens_test.go
@@ -7,7 +7,7 @@ import (
 
 // TestAccRollbarProjectAccessTokensDataSource tests reading project access
 // tokens with `rollbar_project_access_tokens` data source.
-func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
+func (s *AccSuite) TestAccRollbarProjectAccessTokensDataSource() {
 	rn := "data.rollbar_project_access_tokens.test"
 
 	resource.Test(s.T(), resource.TestCase{
@@ -52,7 +52,7 @@ func (s *Suite) TestAccRollbarProjectAccessTokensDataSource() {
 // configDataSourceRollbarProjectAccessTokens generates Terraform configuration
 // for resource `rollbar_project_access_tokens`. If `prefix` is not empty, it
 // will be supplied as the `prefix` argument to the data source.
-func (s *Suite) configDataSourceRollbarProjectAccessTokens(prefix string) string {
+func (s *AccSuite) configDataSourceRollbarProjectAccessTokens(prefix string) string {
 	var configPrefix string
 	if prefix != "" {
 		configPrefix = fmt.Sprintf(`prefix = "%s"`, prefix)

--- a/rollbar/data_source_project_test.go
+++ b/rollbar/data_source_project_test.go
@@ -7,7 +7,7 @@ import (
 
 // TestAccRollbarProjectDataSource tests reading a project with
 // `rollbar_project` data source.
-func (s *Suite) TestAccRollbarProjectDataSource() {
+func (s *AccSuite) TestAccRollbarProjectDataSource() {
 	rn := "data.rollbar_project.test"
 
 	resource.Test(s.T(), resource.TestCase{
@@ -28,7 +28,7 @@ func (s *Suite) TestAccRollbarProjectDataSource() {
 	})
 }
 
-func (s *Suite) configDataSourceRollbarProject() string {
+func (s *AccSuite) configDataSourceRollbarProject() string {
 	// language=hcl
 	tmpl := `
 		resource "rollbar_project" "test" {

--- a/rollbar/data_source_projects_test.go
+++ b/rollbar/data_source_projects_test.go
@@ -3,12 +3,31 @@ package rollbar_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/rollbar/terraform-provider-rollbar/client"
+	"strconv"
 )
 
 // TestAccRollbarProjectsDataSource tests listing of all projects with
 // `rollbar_projects` data source.
 func (s *Suite) TestAccRollbarProjectsDataSource() {
 	rn := "data.rollbar_projects.all"
+
+	// How many projects should we expect in the project list, after our TF
+	// config creates one more project?  There's no guarantee that the Rollbar
+	// account will have either zero or non-zero project count when test is run.
+	c := s.provider.Meta().(*client.RollbarApiClient)
+	pl, err := c.ListProjects()
+	s.Nil(err)
+	currentProjectCount := len(pl)
+	expectedCount := strconv.Itoa(currentProjectCount + 1)
+
+	// Construct the name of the TF resource that should represent the
+	// newly-created Rollbar project.
+	//
+	// FIXME: This relies on the API always returning projects in ascending
+	//  order of ID.  This API behavior is not documented or guarnateed.
+	index := strconv.Itoa(currentProjectCount) // index counting begins at 0; so no need to add 1 to project count
+	projectNameResource := fmt.Sprintf("projects.%s.name", index)
 
 	resource.Test(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
@@ -19,8 +38,8 @@ func (s *Suite) TestAccRollbarProjectsDataSource() {
 				Config: s.configDataSourceRollbarProjects(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(rn, "projects.#"),
-					resource.TestCheckResourceAttr(rn, "projects.#", "1"),
-					resource.TestCheckResourceAttr(rn, "projects.0.name", s.projectName),
+					resource.TestCheckResourceAttr(rn, "projects.#", expectedCount),
+					resource.TestCheckResourceAttr(rn, projectNameResource, s.projectName),
 				),
 			},
 		},

--- a/rollbar/data_source_projects_test.go
+++ b/rollbar/data_source_projects_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestAccRollbarProjectsDataSource tests listing of all projects with
 // `rollbar_projects` data source.
-func (s *Suite) TestAccRollbarProjectsDataSource() {
+func (s *AccSuite) TestAccRollbarProjectsDataSource() {
 	rn := "data.rollbar_projects.all"
 
 	resource.Test(s.T(), resource.TestCase{
@@ -29,7 +29,7 @@ func (s *Suite) TestAccRollbarProjectsDataSource() {
 	})
 }
 
-func (s *Suite) configDataSourceRollbarProjects() string {
+func (s *AccSuite) configDataSourceRollbarProjects() string {
 	// language=hcl
 	tmpl := `
 		resource "rollbar_project" "test" {
@@ -45,7 +45,7 @@ func (s *Suite) configDataSourceRollbarProjects() string {
 
 // checkRollbarProjectInProjectDataSource tests that newly created project is in
 // the list of all projects returned by data source `rollbar_projects`.
-func (s *Suite) checkRollbarProjectInProjectDataSource(rn string) resource.TestCheckFunc {
+func (s *AccSuite) checkRollbarProjectInProjectDataSource(rn string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
 		// How many projects should we expect in the project list?
 		c := s.provider.Meta().(*client.RollbarApiClient)

--- a/rollbar/provider_test.go
+++ b/rollbar/provider_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 )
 
-// Suite is the acceptance testing suite.
-type Suite struct {
+// AccSuite is the acceptance testing suite.
+type AccSuite struct {
 	suite.Suite
 	provider  *schema.Provider
 	providers map[string]*schema.Provider
@@ -33,7 +33,7 @@ type Suite struct {
 	projectName string // Name of a Rollbar project
 }
 
-func (s *Suite) SetupSuite() {
+func (s *AccSuite) SetupSuite() {
 	// Log to console
 	log.Logger = log.
 		With().Caller().
@@ -52,23 +52,23 @@ func (s *Suite) SetupSuite() {
 }
 
 // preCheck ensures we are ready to run the test
-func (s *Suite) preCheck() {
+func (s *AccSuite) preCheck() {
 	token := os.Getenv("ROLLBAR_TOKEN")
 	s.NotEmpty(token, "ROLLBAR_TOKEN must be set for acceptance tests")
 	log.Debug().Msg("Passed preflight check")
 }
 
-func (s *Suite) SetupTest() {
+func (s *AccSuite) SetupTest() {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	s.projectName = fmt.Sprintf("tf-acc-test-%s", randString)
 }
 
 func TestAccSuite(t *testing.T) {
-	suite.Run(t, new(Suite))
+	suite.Run(t, new(AccSuite))
 }
 
 // getResourceIDString returns the ID string of a resource.
-func (s *Suite) getResourceIDString(ts *terraform.State, resourceName string) (string, error) {
+func (s *AccSuite) getResourceIDString(ts *terraform.State, resourceName string) (string, error) {
 	var id string
 	rs, ok := ts.RootModule().Resources[resourceName]
 	if !ok {
@@ -82,7 +82,7 @@ func (s *Suite) getResourceIDString(ts *terraform.State, resourceName string) (s
 }
 
 // getResourceIDInt returns the ID of a resource as an integer.
-func (s *Suite) getResourceIDInt(ts *terraform.State, resourceName string) (int, error) {
+func (s *AccSuite) getResourceIDInt(ts *terraform.State, resourceName string) (int, error) {
 	var id int
 	idString, err := s.getResourceIDString(ts, resourceName)
 	if err != nil {
@@ -97,7 +97,7 @@ func (s *Suite) getResourceIDInt(ts *terraform.State, resourceName string) (int,
 
 // checkResourceStateSanity checks that the resource is present in the Terraform
 // state, and that its ID is set.
-func (s *Suite) checkResourceStateSanity(rn string) resource.TestCheckFunc {
+func (s *AccSuite) checkResourceStateSanity(rn string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
 		_, err := s.getResourceIDString(ts, rn)
 		return err

--- a/rollbar/provider_test.go
+++ b/rollbar/provider_test.go
@@ -63,7 +63,7 @@ func (s *Suite) SetupTest() {
 	s.projectName = fmt.Sprintf("tf-acc-test-%s", randString)
 }
 
-func TestSuite(t *testing.T) {
+func TestAccSuite(t *testing.T) {
 	suite.Run(t, new(Suite))
 }
 

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // TestAccRollbarProject tests creation and deletion of a Rollbar project.
-func (s *Suite) TestAccRollbarProject() {
+func (s *AccSuite) TestAccRollbarProject() {
 	rn := "rollbar_project.foo"
 
 	resource.Test(s.T(), resource.TestCase{
@@ -39,7 +39,7 @@ func (s *Suite) TestAccRollbarProject() {
 	})
 }
 
-func (s *Suite) configResourceRollbarProject() string {
+func (s *AccSuite) configResourceRollbarProject() string {
 	// language=hcl
 	tmpl := `
 		resource "rollbar_project" "foo" {
@@ -50,7 +50,7 @@ func (s *Suite) configResourceRollbarProject() string {
 }
 
 // checkRollbarProjectExists tests that the newly created project exists
-func (s *Suite) checkRollbarProjectExists(rn string, name string) resource.TestCheckFunc {
+func (s *AccSuite) checkRollbarProjectExists(rn string, name string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
 		id, err := s.getResourceIDInt(ts, rn)
 		if err != nil {
@@ -70,7 +70,7 @@ func (s *Suite) checkRollbarProjectExists(rn string, name string) resource.TestC
 
 // checkRollbarProjectInProjectList tests that the newly created project is
 // present in the list of all projects.
-func (s *Suite) checkRollbarProjectInProjectList(rn string) resource.TestCheckFunc {
+func (s *AccSuite) checkRollbarProjectInProjectList(rn string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
 		id, err := s.getResourceIDInt(ts, rn)
 		if err != nil {


### PR DESCRIPTION
This PR closes #32 by refactoring the tests so they can pass regardless if there are zero or non-zero number of projects already present in the Rollbar account.