### PR TITLE
Workflow for golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+on:
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.29
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true

--- a/rollbar/data_source_project.go
+++ b/rollbar/data_source_project.go
@@ -55,8 +55,14 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	id := fmt.Sprintf("%d", project.Id)
 	d.SetId(id)
-	d.Set("account_id", project.AccountId)
-	d.Set("date_created", project.DateCreated)
+	err = d.Set("account_id", project.AccountId)
+	if err != nil {
+		return err
+	}
+	err = d.Set("date_created", project.DateCreated)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/rollbar/resource_project.go
+++ b/rollbar/resource_project.go
@@ -114,9 +114,13 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 	return diags
 }
 
+/*
+No need for this function until we have update support in the Rollbar API.
+
 func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	return resourceProjectRead(ctx, d, m)
 }
+*/
 
 func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics


### PR DESCRIPTION
This PR closes #40 by adding a Github Actions workflow to run `golangci-lint`.  