### PR TITLE
Godoc link for client subpackage

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,5 +1,5 @@
-Rollbar API Client
-==================
+Rollbar Management API Client
+=============================
 
 A client for the Rollbar API, providing access to project & team management
 functionality. Used internally by the Rollbar Terraform provider.  Does **not**

--- a/client/README.md
+++ b/client/README.md
@@ -1,2 +1,12 @@
 Rollbar API Client
 ==================
+
+A client for the Rollbar API, providing access to project & team management
+functionality. Used internally by the Rollbar Terraform provider.  Does **not**
+provide error reporting functionality. If you want to use Rollbar to collect
+errors from your application, this is the wrong client.
+
+See [`rollbar-go`](https://github.com/rollbar/rollbar-go) for the official Go
+client for Rollbar, which *does* provide support for error reporting.
+
+[![Documentation](https://godoc.org/github.com/rollbar/terraform-provider-rollbar?status.svg)](http://godoc.org/github.com/rollbar/terraform-provider-rollbar)

--- a/client/README.md
+++ b/client/README.md
@@ -9,4 +9,8 @@ errors from your application, this is the wrong client.
 See [`rollbar-go`](https://github.com/rollbar/rollbar-go) for the official Go
 client for Rollbar, which *does* provide support for error reporting.
 
+
+Documentation
+-------------
+
 [![Documentation](https://godoc.org/github.com/rollbar/terraform-provider-rollbar?status.svg)](http://godoc.org/github.com/rollbar/terraform-provider-rollbar)


### PR DESCRIPTION
This PR closes #10 by adding a link to GoDoc in the `client` package's README.