### PR TITLE
Resource `rollbar_team`

### DIFF
--- a/client/team.go
+++ b/client/team.go
@@ -130,6 +130,13 @@ func (c *RollbarApiClient) ReadTeam(id int) (Team, error) {
 	}
 	err = errorFromResponse(resp)
 	if err != nil {
+		// FIXME: Workaround API bug
+		//  https://github.com/rollbar/terraform-provider-rollbar/issues/79
+		statusForbidden := resp.StatusCode() == http.StatusForbidden
+		msgNotFound := strings.Contains(err.Error(), "Team not found in this account")
+		if statusForbidden && msgNotFound {
+			return t, ErrNotFound
+		}
 		l.Err(err).Msg("Error reading team")
 		return t, err
 	}

--- a/client/team.go
+++ b/client/team.go
@@ -35,25 +35,15 @@ type Team struct {
 	ID          int
 	AccountID   int `json:"account_id"`
 	Name        string
-	AccessLevel TeamAccessLevel `json:"access_level"`
+	AccessLevel string `json:"access_level"`
 }
 
-// TeamAccessLevel represents the Rollbar team access level.
-type TeamAccessLevel string
-
-// Possible values for team access level
-const (
-	TeamAccessStandard = TeamAccessLevel("standard")
-	TeamAccessLight    = TeamAccessLevel("light")
-	TeamAccessView     = TeamAccessLevel("view")
-)
-
 // CreateTeam creates a new Rollbar team.
-func (c *RollbarApiClient) CreateTeam(name string, level TeamAccessLevel) (Team, error) {
+func (c *RollbarApiClient) CreateTeam(name string, level string) (Team, error) {
 	var t Team
 	l := log.With().
 		Str("name", name).
-		Str("access_level", string(level)).
+		Str("access_level", level).
 		Logger()
 	l.Debug().Msg("Creating new team")
 

--- a/client/team.go
+++ b/client/team.go
@@ -54,7 +54,10 @@ func (c *RollbarApiClient) CreateTeam(name string, level string) (Team, error) {
 
 	u := apiUrl + pathTeamCreate
 	resp, err := c.Resty.R().
-		SetBody(map[string]interface{}{"name": name}).
+		SetBody(map[string]interface{}{
+			"name":         name,
+			"access_level": level,
+		}).
 		SetResult(teamCreateResponse{}).
 		SetError(ErrorResult{}).
 		Post(u)

--- a/client/team_test.go
+++ b/client/team_test.go
@@ -33,25 +33,24 @@ import (
 func (s *Suite) TestCreateTeam() {
 	// Setup API mock
 	teamName := "foobar"
+	accessLevel := "standard"
 	u := apiUrl + pathTeamCreate
 	expected := Team{
 		ID:          676974,
 		AccountID:   317418,
 		Name:        teamName,
-		AccessLevel: "standard",
+		AccessLevel: accessLevel,
 	}
 	// FIXME: currently API returns `200 OK` on successful create; but it should
 	//  instead return `201 Created`.
 	//  https://github.com/rollbar/terraform-provider-rollbar/issues/8
 	sr := responseFromFixture("team/create.json", http.StatusOK)
 	r := func(req *http.Request) (*http.Response, error) {
-		type body struct {
-			Name string
-		}
-		b := body{}
+		b := make(map[string]interface{})
 		err := json.NewDecoder(req.Body).Decode(&b)
 		s.Nil(err)
-		s.Equal(teamName, b.Name)
+		s.Equal(teamName, b["name"])
+		s.Equal(accessLevel, b["access_level"])
 		return sr, nil
 	}
 	httpmock.RegisterResponder("POST", u, r)

--- a/client/team_test.go
+++ b/client/team_test.go
@@ -38,7 +38,7 @@ func (s *Suite) TestCreateTeam() {
 		ID:          676974,
 		AccountID:   317418,
 		Name:        teamName,
-		AccessLevel: TeamAccessStandard,
+		AccessLevel: "standard",
 	}
 	// FIXME: currently API returns `200 OK` on successful create; but it should
 	//  instead return `201 Created`.
@@ -57,30 +57,30 @@ func (s *Suite) TestCreateTeam() {
 	httpmock.RegisterResponder("POST", u, r)
 
 	// Successful create
-	actual, err := s.client.CreateTeam(teamName, TeamAccessStandard)
+	actual, err := s.client.CreateTeam(teamName, "standard")
 	s.Nil(err)
 	s.Equal(expected, actual)
 
 	// Invalid name
-	_, err = s.client.CreateTeam("", TeamAccessStandard)
+	_, err = s.client.CreateTeam("", "standard")
 	s.NotNil(err)
 
 	// Internal server error
 	r = httpmock.NewJsonResponderOrPanic(http.StatusInternalServerError, errResult500)
 	httpmock.RegisterResponder("POST", u, r)
-	_, err = s.client.CreateTeam(teamName, TeamAccessStandard)
+	_, err = s.client.CreateTeam(teamName, "standard")
 	s.NotNil(err)
 
 	// Server unreachable
 	httpmock.Reset()
-	_, err = s.client.CreateTeam(teamName, TeamAccessStandard)
+	_, err = s.client.CreateTeam(teamName, "standard")
 	s.NotNil(err)
 
 	// Unauthorized
 	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
 		ErrorResult{Err: 401, Message: "Unauthorized"})
 	httpmock.RegisterResponder("POST", u, r)
-	_, err = s.client.CreateTeam(teamName, TeamAccessStandard)
+	_, err = s.client.CreateTeam(teamName, "standard")
 	s.Equal(ErrUnauthorized, err)
 }
 
@@ -98,7 +98,7 @@ func (s *Suite) TestListTeams() {
 			ID:          676974,
 			AccountID:   317418,
 			Name:        "foobar",
-			AccessLevel: TeamAccessStandard,
+			AccessLevel: "standard",
 		},
 		{
 			AccessLevel: "owner",
@@ -143,7 +143,7 @@ func (s *Suite) TestReadTeam() {
 		ID:          676974,
 		AccountID:   317418,
 		Name:        "foobar",
-		AccessLevel: TeamAccessStandard,
+		AccessLevel: "standard",
 	}
 	r := responderFromFixture("team/read.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)

--- a/client/team_test.go
+++ b/client/team_test.go
@@ -130,6 +130,14 @@ func (s *Suite) TestReadTeam() {
 	_, err = s.client.ReadTeam(0)
 	s.NotNil(err)
 
+	// FIXME: Workaround API bug
+	//  https://github.com/rollbar/terraform-provider-rollbar/issues/79
+	r = httpmock.NewJsonResponderOrPanic(http.StatusForbidden,
+		ErrorResult{Err: 1, Message: "Team not found in this account."})
+	httpmock.RegisterResponder("GET", u, r)
+	_, err = s.client.ReadTeam(teamId)
+	s.Equal(ErrNotFound, err)
+
 	s.checkServerErrors("GET", u, func() error {
 		_, err := s.client.ReadTeam(teamId)
 		return err

--- a/client/team_test.go
+++ b/client/team_test.go
@@ -64,23 +64,10 @@ func (s *Suite) TestCreateTeam() {
 	_, err = s.client.CreateTeam("", "standard")
 	s.NotNil(err)
 
-	// Internal server error
-	r = httpmock.NewJsonResponderOrPanic(http.StatusInternalServerError, errResult500)
-	httpmock.RegisterResponder("POST", u, r)
-	_, err = s.client.CreateTeam(teamName, "standard")
-	s.NotNil(err)
-
-	// Server unreachable
-	httpmock.Reset()
-	_, err = s.client.CreateTeam(teamName, "standard")
-	s.NotNil(err)
-
-	// Unauthorized
-	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
-		ErrorResult{Err: 401, Message: "Unauthorized"})
-	httpmock.RegisterResponder("POST", u, r)
-	_, err = s.client.CreateTeam(teamName, "standard")
-	s.Equal(ErrUnauthorized, err)
+	s.checkServerErrors("POST", u, func() error {
+		_, err = s.client.CreateTeam(teamName, "standard")
+		return err
+	})
 }
 
 func (s *Suite) TestListTeams() {
@@ -114,23 +101,10 @@ func (s *Suite) TestListTeams() {
 	s.Nil(err)
 	s.Equal(expected, actual)
 
-	// Internal server error
-	r = httpmock.NewJsonResponderOrPanic(http.StatusInternalServerError, errResult500)
-	httpmock.RegisterResponder("GET", u, r)
-	_, err = s.client.ListTeams()
-	s.NotNil(err)
-
-	// Server unreachable
-	httpmock.Reset()
-	_, err = s.client.ListTeams()
-	s.NotNil(err)
-
-	// Unauthorized
-	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
-		ErrorResult{Err: 401, Message: "Unauthorized"})
-	httpmock.RegisterResponder("GET", u, r)
-	_, err = s.client.ListTeams()
-	s.Equal(ErrUnauthorized, err)
+	s.checkServerErrors("GET", u, func() error {
+		_, err := s.client.ListTeams()
+		return err
+	})
 }
 
 func (s *Suite) TestReadTeam() {
@@ -156,23 +130,10 @@ func (s *Suite) TestReadTeam() {
 	_, err = s.client.ReadTeam(0)
 	s.NotNil(err)
 
-	// Internal server error
-	r = httpmock.NewJsonResponderOrPanic(http.StatusInternalServerError, errResult500)
-	httpmock.RegisterResponder("GET", u, r)
-	_, err = s.client.ReadTeam(teamId)
-	s.NotNil(err)
-
-	// Server unreachable
-	httpmock.Reset()
-	_, err = s.client.ReadTeam(teamId)
-	s.NotNil(err)
-
-	// Unauthorized
-	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
-		ErrorResult{Err: 401, Message: "Unauthorized"})
-	httpmock.RegisterResponder("GET", u, r)
-	_, err = s.client.ReadTeam(teamId)
-	s.Equal(ErrUnauthorized, err)
+	s.checkServerErrors("GET", u, func() error {
+		_, err := s.client.ReadTeam(teamId)
+		return err
+	})
 }
 
 func (s *Suite) TestDeleteTeam() {
@@ -191,23 +152,9 @@ func (s *Suite) TestDeleteTeam() {
 	err = s.client.DeleteTeam(0)
 	s.NotNil(err)
 
-	// Internal server error
-	r = httpmock.NewJsonResponderOrPanic(http.StatusInternalServerError, errResult500)
-	httpmock.RegisterResponder("DELETE", u, r)
-	err = s.client.DeleteTeam(teamId)
-	s.NotNil(err)
-
-	// Server unreachable
-	httpmock.Reset()
-	err = s.client.DeleteTeam(teamId)
-	s.NotNil(err)
-
-	// Unauthorized
-	r = httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized,
-		ErrorResult{Err: 401, Message: "Unauthorized"})
-	httpmock.RegisterResponder("DELETE", u, r)
-	err = s.client.DeleteTeam(teamId)
-	s.Equal(ErrUnauthorized, err)
+	s.checkServerErrors("DELETE", u, func() error {
+		return s.client.DeleteTeam(teamId)
+	})
 }
 
 // TestAssignUserToTeam tests assigning a user to a Rollbar team.

--- a/rollbar/data_source_project_access_token_test.go
+++ b/rollbar/data_source_project_access_token_test.go
@@ -32,7 +32,7 @@ import (
 func (s *AccSuite) TestAccProjectAccessTokenDataSource() {
 	rn := "data.rollbar_project_access_token.test"
 
-	resource.Test(s.T(), resource.TestCase{
+	resource.ParallelTest(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
 		Providers:    s.providers,
 		CheckDestroy: nil,

--- a/rollbar/data_source_project_access_tokens_test.go
+++ b/rollbar/data_source_project_access_tokens_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// TestAccProjectAccessTokensDataSource tests reading project access tokens with
-// `rollbar_project_access_tokens` data source.
-func (s *AccSuite) TestAccProjectAccessTokensDataSource() {
+// TestAccProjectAccessTokensDataSourceNoPrefix tests reading project access
+// tokens with `rollbar_project_access_tokens` data source, with no prefix
+// specified.
+func (s *AccSuite) TestAccProjectAccessTokensDataSourceNoPrefix() {
 	rn := "data.rollbar_project_access_tokens.test"
-
-	resource.Test(s.T(), resource.TestCase{
+	resource.ParallelTest(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
 		Providers:    s.providers,
 		CheckDestroy: nil,
@@ -50,8 +50,14 @@ func (s *AccSuite) TestAccProjectAccessTokensDataSource() {
 			},
 		},
 	})
+}
 
-	resource.Test(s.T(), resource.TestCase{
+// TestAccProjectAccessTokensDataSourceWithPrefix tests reading project access
+// tokens with `rollbar_project_access_tokens` data source, with a specific
+// prefix.
+func (s *AccSuite) TestAccProjectAccessTokensDataSourceWithPrefix() {
+	rn := "data.rollbar_project_access_tokens.test"
+	resource.ParallelTest(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
 		Providers:    s.providers,
 		CheckDestroy: nil,

--- a/rollbar/data_source_project_test.go
+++ b/rollbar/data_source_project_test.go
@@ -34,7 +34,7 @@ import (
 func (s *AccSuite) TestAccProjectDataSource() {
 	rn := "data.rollbar_project.test"
 
-	resource.Test(s.T(), resource.TestCase{
+	resource.ParallelTest(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
 		Providers:    s.providers,
 		CheckDestroy: nil,

--- a/rollbar/provider.go
+++ b/rollbar/provider.go
@@ -52,6 +52,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"rollbar_project":              resourceProject(),
 			"rollbar_project_access_token": resourceProjectAccessToken(),
+			"rollbar_team":                 resourceTeam(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"rollbar_project":               dataSourceProject(),

--- a/rollbar/resource_project.go
+++ b/rollbar/resource_project.go
@@ -24,7 +24,6 @@ package rollbar
 
 import (
 	"context"
-	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/mapstructure"
@@ -110,14 +109,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 	c := m.(*client.RollbarApiClient)
 	proj, err := c.ReadProject(id)
 	if err == client.ErrNotFound {
-		d.SetId("")
-		msg := fmt.Sprintf("Removing project %d from state because it was not found on Rollbar", id)
-		l.Err(err).Msg(msg)
-		return diag.Diagnostics{{
-			Severity: diag.Warning,
-			Summary:  "Project not found, removed from state",
-			Detail:   msg,
-		}}
+		return handleErrNotFound(d, "project")
 	}
 	if err != nil {
 		return diag.FromErr(err)

--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -160,14 +160,7 @@ func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData,
 	c := m.(*client.RollbarApiClient)
 	pat, err := c.ReadProjectAccessToken(projectId, accessToken)
 	if err == client.ErrNotFound {
-		d.SetId("")
-		msg := fmt.Sprintf("Removing project access token `%s` on project %d from state because it was not found on Rollbar", accessToken, projectId)
-		l.Err(err).Msg(msg)
-		return diag.Diagnostics{{
-			Severity: diag.Warning,
-			Summary:  "Project access token not found, removed from state",
-			Detail:   msg,
-		}}
+		return handleErrNotFound(d, "project access token")
 	}
 	if err != nil {
 		return diag.FromErr(err)

--- a/rollbar/resource_project_access_token_test.go
+++ b/rollbar/resource_project_access_token_test.go
@@ -37,7 +37,7 @@ import (
 func (s *AccSuite) TestAccProjectAccessToken() {
 	rn := "rollbar_project_access_token.test" // Resource name
 
-	resource.Test(s.T(), resource.TestCase{
+	resource.ParallelTest(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
 		Providers:    s.providers,
 		CheckDestroy: nil,

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -111,14 +111,15 @@ func (s *AccSuite) checkProjectInProjectList(rn string) resource.TestCheckFunc {
 }
 
 func sweepResourceProject(_ string) error {
-	log.Info().Msg("Cleaning up orphaned Rollbar projects from failed acceptance test runs.")
+	log.Info().Msg("Cleaning up Rollbar projects from acceptance test runs.")
 
 	token := os.Getenv("ROLLBAR_API_KEY")
 	c := client.NewClient(token)
 
 	projects, err := c.ListProjects()
 	if err != nil {
-		log.Fatal().Err(err).Send()
+		log.Err(err).Send()
+		return err
 	}
 
 	for _, p := range projects {
@@ -129,12 +130,13 @@ func sweepResourceProject(_ string) error {
 		if strings.HasPrefix(p.Name, "tf-acc-test-") {
 			err = c.DeleteProject(p.Id)
 			if err != nil {
-				l.Fatal().Err(err).Send()
+				l.Err(err).Send()
+				return err
 			}
 			l.Info().Msg("Deleted project")
 		}
 	}
 
-	log.Info().Msg("Cleanup complete")
+	log.Info().Msg("Projects cleanup complete")
 	return nil
 }

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -113,9 +113,7 @@ func (s *AccSuite) checkProjectInProjectList(rn string) resource.TestCheckFunc {
 func sweepResourceProject(_ string) error {
 	log.Info().Msg("Cleaning up Rollbar projects from acceptance test runs.")
 
-	token := os.Getenv("ROLLBAR_API_KEY")
-	c := client.NewClient(token)
-
+	c := client.NewClient(os.Getenv("ROLLBAR_API_KEY"))
 	projects, err := c.ListProjects()
 	if err != nil {
 		log.Err(err).Send()

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -43,7 +43,7 @@ func init() {
 func (s *AccSuite) TestAccProject() {
 	rn := "rollbar_project.foo"
 
-	resource.Test(s.T(), resource.TestCase{
+	resource.ParallelTest(s.T(), resource.TestCase{
 		PreCheck: func() { s.preCheck() },
 		//ProviderFactories: testAccProviderFactories(),
 		Providers:    s.providers,

--- a/rollbar/resource_team.go
+++ b/rollbar/resource_team.go
@@ -77,7 +77,7 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	errs = append(errs, d.Set("access_level", t.AccessLevel))
 	for _, err = range errs {
 		if err != nil {
-			l.Err(errs[0]).Send()
+			l.Error().Interface("errs", errs).Send()
 			return diag.FromErr(errs[0])
 		}
 	}

--- a/rollbar/resource_team.go
+++ b/rollbar/resource_team.go
@@ -1,0 +1,101 @@
+package rollbar
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/rollbar/terraform-provider-rollbar/client"
+	"github.com/rs/zerolog/log"
+	"strconv"
+)
+
+// resourceTeam constructs a resource representing a Rollbar team.
+func resourceTeam() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTeamCreate,
+		ReadContext:   resourceTeamRead,
+		DeleteContext: resourceTeamDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"access_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"account_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	name := d.Get("name").(string)
+	level := d.Get("name").(string)
+	l := log.With().Str("name", name).Str("access_level", level).Logger()
+	l.Info().Msg("Creating new Rollbar team")
+	c := m.(*client.RollbarApiClient)
+	t, err := c.CreateTeam(name, level)
+	if err != nil {
+		l.Err(err).Send()
+		return diag.FromErr(err)
+	}
+	d.SetId(strconv.Itoa(t.ID))
+	l.Info().Int("id", t.ID).Msg("Successfully created Rollbar team")
+	return resourceTeamRead(ctx, d, m)
+}
+
+func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	l := log.With().Int("id", id).Logger()
+	l.Info().Msg("Reading Rollbar team from API")
+	c := m.(*client.RollbarApiClient)
+	t, err := c.ReadTeam(id)
+	if err == client.ErrNotFound {
+		return handleErrNotFound(d, "team")
+	}
+	if err != nil {
+		l.Err(err).Send()
+		return diag.FromErr(err)
+	}
+	var errs []error
+	errs = append(errs, d.Set("name", t.Name))
+	errs = append(errs, d.Set("account_id", t.AccountID))
+	errs = append(errs, d.Set("access_level", t.AccessLevel))
+	if errs != nil {
+		l.Err(errs[0]).Send()
+		return diag.FromErr(errs[0])
+	}
+	l.Info().Msg("Successfully read Rollbar team from API")
+	return nil
+}
+
+func resourceTeamDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	l := log.With().Int("id", id).Logger()
+	l.Info().Msg("Deleting Rollbar team")
+	c := m.(*client.RollbarApiClient)
+	err = c.DeleteTeam(id)
+	if err != nil {
+		l.Err(err).Send()
+		return diag.FromErr(err)
+	}
+	l.Info().Msg("Successfully deleted Rollbar team")
+	return nil
+}

--- a/rollbar/resource_team.go
+++ b/rollbar/resource_team.go
@@ -69,7 +69,6 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		return handleErrNotFound(d, "team")
 	}
 	if err != nil {
-		l.Err(err).Send()
 		return diag.FromErr(err)
 	}
 	var errs []error

--- a/rollbar/resource_team.go
+++ b/rollbar/resource_team.go
@@ -29,6 +29,7 @@ func resourceTeam() *schema.Resource {
 			"access_level": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "standard",
 				ForceNew: true,
 			},
 			"account_id": {
@@ -41,7 +42,7 @@ func resourceTeam() *schema.Resource {
 
 func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	name := d.Get("name").(string)
-	level := d.Get("name").(string)
+	level := d.Get("access_level").(string)
 	l := log.With().Str("name", name).Str("access_level", level).Logger()
 	l.Info().Msg("Creating new Rollbar team")
 	c := m.(*client.RollbarApiClient)
@@ -75,9 +76,11 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	errs = append(errs, d.Set("name", t.Name))
 	errs = append(errs, d.Set("account_id", t.AccountID))
 	errs = append(errs, d.Set("access_level", t.AccessLevel))
-	if errs != nil {
-		l.Err(errs[0]).Send()
-		return diag.FromErr(errs[0])
+	for _, err = range errs {
+		if err != nil {
+			l.Err(errs[0]).Send()
+			return diag.FromErr(errs[0])
+		}
 	}
 	l.Info().Msg("Successfully read Rollbar team from API")
 	return nil

--- a/rollbar/resource_team_test.go
+++ b/rollbar/resource_team_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rollbar/terraform-provider-rollbar/client"
 	"github.com/rs/zerolog/log"
 	"os"
+	"regexp"
 	"strings"
 )
 
@@ -29,6 +30,12 @@ func (s *AccSuite) TestAccTeam() {
 		Providers:    s.providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
+			// Invalid name - failure expected
+			{
+				Config:      s.configResourceTeamInvalidname(),
+				ExpectError: regexp.MustCompile("name cannot be blank"),
+			},
+
 			// Initial create
 			{
 				Config: s.configResourceTeam(teamName0),
@@ -89,6 +96,16 @@ func (s *AccSuite) TestAccTeam() {
 			},
 		},
 	})
+}
+
+func (s *AccSuite) configResourceTeamInvalidname() string {
+	// language=hcl
+	tmpl := `
+		resource "rollbar_team" "test" {
+			name = ""
+		}
+	`
+	return tmpl
 }
 
 func (s *AccSuite) configResourceTeam(teamName string) string {

--- a/rollbar/resource_team_test.go
+++ b/rollbar/resource_team_test.go
@@ -23,7 +23,7 @@ func (s *AccSuite) TestAccTeam() {
 	teamName0 := fmt.Sprintf("%s-team-0", s.projectName)
 	teamName1 := fmt.Sprintf("%s-team-0", s.projectName)
 
-	resource.Test(s.T(), resource.TestCase{
+	resource.ParallelTest(s.T(), resource.TestCase{
 		PreCheck: func() { s.preCheck() },
 		//ProviderFactories: testAccProviderFactories(),
 		Providers:    s.providers,

--- a/rollbar/resource_team_test.go
+++ b/rollbar/resource_team_test.go
@@ -1,0 +1,1 @@
+package rollbar_test

--- a/rollbar/resource_team_test.go
+++ b/rollbar/resource_team_test.go
@@ -29,6 +29,7 @@ func (s *AccSuite) TestAccTeam() {
 		Providers:    s.providers,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
+			// Initial create
 			{
 				Config: s.configResourceTeam(teamName0),
 				Check: resource.ComposeTestCheckFunc(
@@ -37,6 +38,8 @@ func (s *AccSuite) TestAccTeam() {
 					s.checkTeam(rn, teamName0, "standard"),
 				),
 			},
+
+			// Update team access level
 			{
 				Config: s.configResourceTeamUpdateAccessLevel(teamName0),
 				Check: resource.ComposeTestCheckFunc(
@@ -45,6 +48,8 @@ func (s *AccSuite) TestAccTeam() {
 					s.checkTeam(rn, teamName0, "light"),
 				),
 			},
+
+			// Update team name
 			{
 				Config: s.configResourceTeamUpdateTeamName(teamName1),
 				Check: resource.ComposeTestCheckFunc(
@@ -53,8 +58,9 @@ func (s *AccSuite) TestAccTeam() {
 					s.checkTeam(rn, teamName1, "light"),
 				),
 			},
+
+			// Before running Terraform, delete the team on Rollbar but not in local state
 			{
-				// Before running Terraform we delete the team on Rollbar but not in local state
 				PreConfig: func() {
 					c := client.NewClient(os.Getenv("ROLLBAR_API_KEY"))
 					teams, err := c.ListTeams()
@@ -74,6 +80,8 @@ func (s *AccSuite) TestAccTeam() {
 					s.checkTeam(rn, teamName1, "light"),
 				),
 			},
+
+			// Import a team
 			{
 				ResourceName:      rn,
 				ImportState:       true,

--- a/rollbar/resource_team_test.go
+++ b/rollbar/resource_team_test.go
@@ -1,1 +1,104 @@
 package rollbar_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/rollbar/terraform-provider-rollbar/client"
+	"github.com/rs/zerolog/log"
+	"os"
+	"strings"
+)
+
+func init() {
+	resource.AddTestSweepers("rollbar_team", &resource.Sweeper{
+		Name: "rollbar_team",
+		F:    sweepResourceTeam,
+	})
+}
+
+// TestAccTeam tests CRUD operations for a Rollbar team.
+func (s *AccSuite) TestAccTeam() {
+	rn := "rollbar_team.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		PreCheck: func() { s.preCheck() },
+		//ProviderFactories: testAccProviderFactories(),
+		Providers:    s.providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				// language=hcl-terraform
+				Config: s.configResourceTeam(),
+				Check: resource.ComposeTestCheckFunc(
+					s.checkResourceStateSanity(rn),
+					resource.TestCheckResourceAttr(rn, "name", s.projectName),
+					s.checkTeam(rn),
+					//s.checkProjectInProjectList(rn),
+				),
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func (s *AccSuite) configResourceTeam() string {
+	// langauge=hcl
+	tmpl := `
+		resource "rollbar_team" "test" {
+			name = "%s"
+		}
+	`
+	teamName := fmt.Sprintf("%s-team-0", s.projectName)
+	return fmt.Sprintf(tmpl, teamName)
+
+}
+
+// checkTeam checks that the newly created team exists and has correct
+// attributes.
+func (s *AccSuite) checkTeam(rn string) resource.TestCheckFunc {
+	return func(ts *terraform.State) error {
+		id, err := s.getResourceIDInt(ts, rn)
+		s.Nil(err)
+		c := s.provider.Meta().(*client.RollbarApiClient)
+		t, err := c.ReadTeam(id)
+		s.Nil(err)
+		s.Equal(s.projectName, t.Name, "team name from API does not match team name in Terraform config")
+		s.Equal("standard", t.AccessLevel)
+		return nil
+	}
+}
+
+func sweepResourceTeam(_ string) error {
+	log.Info().Msg("Cleaning up Rollbar teams from acceptance test runs.")
+	token := os.Getenv("ROLLBAR_API_KEY")
+	c := client.NewClient(token)
+
+	teams, err := c.ListTeams()
+	if err != nil {
+		log.Err(err).Send()
+		return err
+	}
+
+	for _, t := range teams {
+		l := log.With().
+			Str("name", t.Name).
+			Int("id", t.ID).
+			Logger()
+		if strings.HasPrefix(t.Name, "tf-acc-test-") {
+			err = c.DeleteTeam(t.ID)
+			if err != nil {
+				l.Err(err).Send()
+				return err
+			}
+			l.Info().Msg("Deleted team")
+		}
+	}
+
+	log.Info().Msg("Teams cleanup complete")
+	return nil
+}


### PR DESCRIPTION
This PR closes #77 by implementing resource `rollbar_team`.  

This PR also adds parallelization to the acceptance tests, improving test speed.