### PR TITLE
Terraform 0.12 compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Git
+.git/
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Environment variables
+.env
+
+# IntelliJ / GoLand
+.idea/
+
+# Vim
+*.swp
+
+# Terraform
+terraform.tfstate*
+*.tfvars
+.terraform/
+
+# ShiftLeft Scan reports
+reports/
+
+# Debug logs
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,13 +58,9 @@ RUN ["/bin/bash", "-c", "echo $version; if [[ $version == 0.12* ]]; then mv -v p
 RUN terraform init
 
 
-# Required environment variable
-ENV ROLLBAR_API_KEY=
-
-
 # Enable trace logging
 #ENV TF_LOG=TRACE
 
 
 # Terraform plan
-CMD echo $ROLLBAR_API_KEY && terraform plan -var rollbar_token=$ROLLBAR_API_KEY
+ENTRYPOINT ["terraform"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,7 @@ MAINTAINER Jason McVetta <jmcvetta@protonmail.com>
 RUN apk update && apk upgrade --no-cache
 
 
-# Terraform version - supports 0.12.x and 0.13.x
-ARG version=0.13.5
-
-
 # Build folder
-ENV buildfolder=/srv/terraform-provider-rollbar
 
 
 # Build dependencies
@@ -29,12 +24,14 @@ RUN echo "set -o vi" >> ~/.bashrc
 
 
 # Install Terraform
+# Versions 0.12.x and 0.13.x are supported
+ARG version=0.13.5
 RUN curl https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip -o /tmp/terraform.zip
 RUN unzip /tmp/terraform.zip -d /usr/local/bin/
 
 
 # Install Go modules
-WORKDIR ${buildfolder}
+WORKDIR  /srv/terraform-provider-rollbar
 COPY go.mod go.sum ./
 RUN go mod download -x
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY example/*.tf example/*.override example/
 WORKDIR example/
 # Terraform 0.13 `required_providers` syntax is not entirely supported by 0.12,
 # so we override it.
-RUN ["/bin/bash", "-c", "if [[ $version == 0.12* ]]; then mv -v providers012.tf.override providers.tf; fi"]
+RUN ["/bin/bash", "-c", "echo $version; if [[ $version == 0.12* ]]; then mv -v providers012.tf.override providers.tf; fi"]
 
 
 # Initialize provider

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Jason McVetta <jmcvetta@protonmail.com>
 RUN apk update && apk upgrade --no-cache
 
 
-# Terraform version
-ARG version=0.12.29
+# Terraform version - supports 0.12.x and 0.13.x
+ARG version=0.13.5
 
 
 # Build folder
@@ -23,6 +23,8 @@ RUN apk add --no-cache \
         unzip \
         vim
 
+
+# Enable VI-keys
 RUN echo "set -o vi" >> ~/.bashrc
 
 
@@ -37,11 +39,12 @@ COPY go.mod go.sum ./
 RUN go mod download -x
 
 
-# Build provider
+# Build and install provider
 COPY Makefile main.go ./
 COPY client client
 COPY rollbar rollbar
 RUN make build
+RUN make install
 RUN make install012
 
 
@@ -61,7 +64,10 @@ RUN terraform init
 # Required environment variable
 ENV ROLLBAR_API_KEY=
 
+
+# Enable trace logging
 #ENV TF_LOG=TRACE
 
-#ENTRYPOINT terraform -var rollbar_token=$ROLLBAR_API_KEY
+
+# Terraform plan
 CMD echo $ROLLBAR_API_KEY && terraform plan -var rollbar_token=$ROLLBAR_API_KEY

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ RUN apk add --no-cache \
         curl \
         git \
         make \
-        unzip
+        unzip \
+        vim
+
+RUN echo "set -o vi" >> ~/.bashrc
 
 
 # Install Terraform
@@ -39,9 +42,12 @@ COPY Makefile main.go ./
 COPY client client
 COPY rollbar rollbar
 RUN make build
+ENV TF_LOG=TRACE
+RUN make install012
 
 
 # Test provider
 RUN mkdir example
-COPY example/*.tf example/
+COPY example/main.tf example/
+COPY example/providers012.tf.example example/providers012.tf
 RUN make plan

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,11 @@ _terraform_plan:
 	(cd example && TERRAFORM_PROVIDER_ROLLBAR_DEBUG=1 terraform plan)
 _terraform_destroy:
 	(cd example && TERRAFORM_PROVIDER_ROLLBAR_DEBUG=1 terraform destroy)
+
+docker12:
+	docker build . --build-arg version=0.12.5 -t terraform-0.12-provider-rollbar 
+	docker run terraform-0.12-provider-rollbar plan -var rollbar_token=$$ROLLBAR_API_KEY
+
+docker13:
+	docker build . --build-arg version=0.13.5 -t terraform-0.13-provider-rollbar 
+	docker run terraform-0.13-provider-rollbar plan -var rollbar_token=$$ROLLBAR_API_KEY

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
+install012: build
+	mkdir -p ~/.terraform.d/plugins/${OS_ARCH}/
+	mv ${BINARY} ~/.terraform.d/plugins/${OS_ARCH}/terraform-provider-${NAME}_v${VERSION}
+
 test: 
 	go test -covermode=atomic -coverprofile=coverage.out $(TEST) || exit 1
 	@#echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    

--- a/example/main.tf
+++ b/example/main.tf
@@ -21,14 +21,6 @@
  */
 
 
-terraform {
-  required_providers {
-    rollbar = {
-      source  = "github.com/rollbar/rollbar"
-      version = "~> 0.2"
-    }
-  }
-}
 
 variable "rollbar_token" {
   type = string

--- a/example/providers.tf
+++ b/example/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    rollbar = {
+      source  = "github.com/rollbar/rollbar"
+      version = "~> 0.2"
+    }
+  }
+}
+

--- a/example/providers012.tf.override
+++ b/example/providers012.tf.override
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    rollbar = {
+      version = "~> 0.2"
+    }
+  }
+}


### PR DESCRIPTION
This PR closes #127 by demonstrating that the provider is compatible with both Terraform v0.13.x (current) and v0.12.x (still used by some Rollbar customers).  

The Makefile provides two new targets, `docker12` and `docker13`, which run the provider in a Docker container with Terraform v0.12.29 and v0.13.5 respectively.  