### PR TITLE
reenable TestAccTokenUpdateRateLimit

### DIFF
--- a/rollbar/resource_project_access_token_test.go
+++ b/rollbar/resource_project_access_token_test.go
@@ -164,7 +164,7 @@ func (s *AccSuite) TestAccTokenUpdateScope() {
 // TestAccTokenUpdateRateLimit tests updating the rate limit on a Rollbar
 // project access token.
 // FIXME: https://github.com/rollbar/terraform-provider-rollbar/issues/128
-func (s *AccSuite) DontTestAccTokenUpdateRateLimit() {
+func (s *AccSuite) TestAccTokenUpdateRateLimit() {
 	rn := "rollbar_project_access_token.test" // Resource name
 	// language=hcl
 	tmpl1 := `


### PR DESCRIPTION
This PR reverses the kludge introduced in #130, as bug #128 has been fixed.