### PR TITLE
Codeclimate coverage upload

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -64,3 +64,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info
+      - name: Upload coverage data to CodeClimate
+        uses: paambaati/codeclimate-action@v2.7.4
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,7 +68,7 @@ jobs:
         uses: paambaati/codeclimate-action@v2.7.4
         with:
           coverageLocations: |
-            ${{github.workspace}}/*lcov*:lcov
+            ${{github.workspace}}/*coverage*:gocov
 
 
         env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -66,5 +66,9 @@ jobs:
           path-to-lcov: ./lcov.info
       - name: Upload coverage data to CodeClimate
         uses: paambaati/codeclimate-action@v2.7.4
+        with:
+          coverageLocations: |
+            ${{github.workspace}}/coverage.out:gocov
+
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,7 +68,8 @@ jobs:
         uses: paambaati/codeclimate-action@v2.7.4
         with:
           coverageLocations: |
-            ${{github.workspace}}/coverage.out:gocov
+            ${{github.workspace}}/*lcov*:lcov
+
 
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,7 +68,7 @@ jobs:
         uses: paambaati/codeclimate-action@v2.7.4
         with:
           coverageLocations: |
-            ${{github.workspace}}/*coverage*:gocov
+            ${{github.workspace}}/*lcov*:lcov
 
 
         env:


### PR DESCRIPTION
This PR closes #131 by uploading code coverage data to CodeClimate as part of the build & test workflow.