### PR TITLE
Fix example no default tokens

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -30,29 +30,7 @@ provider "rollbar" {
   api_key = var.rollbar_token
 }
 
-/*
- * Adapted from @jtsaito
- */
 
-data "rollbar_project" "test" {
-  name = rollbar_project.test.name
-  depends_on = [rollbar_project.test]
-}
-
-data "rollbar_project_access_token" "post_client_item" {
-  project_id = data.rollbar_project.test.id
-  name       = "post_client_item"
-}
-
-data "rollbar_project_access_token" "post_server_item" {
-  project_id = data.rollbar_project.test.id
-  name       = "post_server_item"
-}
-
-
-/*
- * Added by @jmcvetta
- */
 
 resource "rollbar_project" "test" {
   name = "tf-acc-test-example"
@@ -89,5 +67,15 @@ data "rollbar_projects" "all" {}
 
 data "rollbar_project_access_tokens" "test" {
   project_id = rollbar_project.test.id
-  prefix = "post_"
+  prefix = "test-"
+}
+
+data "rollbar_project" "test" {
+  name = rollbar_project.test.name
+  depends_on = [rollbar_project.test]
+}
+
+data "rollbar_project_access_token" "test_token_1" {
+  project_id = data.rollbar_project.test.id
+  name       = "test-token-1"
 }

--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -209,8 +209,6 @@ func resourceProjectAccessTokenUpdate(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
 	accessToken := d.Id()
 	projectID := d.Get("project_id").(int)
 
@@ -226,14 +224,7 @@ func resourceProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	// FIXME: Implement this functionality when the API is ready!
-	//  https://github.com/rollbar/terraform-provider-rollbar/issues/12
-	diags = diag.Diagnostics{{
-		Severity: diag.Warning,
-		Summary:  "Delete not implemented for resource `rollbar_project_access_token`",
-		Detail:   "https://github.com/rollbar/terraform-provider-rollbar/issues/12",
-	}}
-	return diags
+	return nil
 }
 
 func resourceProjectAccessTokenImporter(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/rollbar/resource_project_access_token_test.go
+++ b/rollbar/resource_project_access_token_test.go
@@ -164,7 +164,6 @@ func (s *AccSuite) TestAccTokenUpdateScope() {
 
 // TestAccTokenUpdateRateLimit tests updating the rate limit on a Rollbar
 // project access token.
-// FIXME: https://github.com/rollbar/terraform-provider-rollbar/issues/128
 func (s *AccSuite) TestAccTokenUpdateRateLimit() {
 	rn := "rollbar_project_access_token.test" // Resource name
 	// language=hcl


### PR DESCRIPTION
This PR removes from the example configuration all dependency on the now-defunct default project access tokens.