### PR TITLE
Test user transition from invited to registered

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -45,6 +45,9 @@ func NewClient(token string) *RollbarApiClient {
 	// New Resty HTTP client
 	r := resty.New()
 
+	// Use default transport - needed for VCR
+	r.SetTransport(http.DefaultTransport)
+
 	// Authentication
 	if token != "" {
 		r = r.SetHeader("X-Rollbar-Access-Token", token)

--- a/client/user.go
+++ b/client/user.go
@@ -100,9 +100,11 @@ func (c *RollbarApiClient) FindUserID(email string) (int, error) {
 	}
 	for _, u := range users {
 		if u.Email == email {
+			l.Debug().Int("user_id", u.ID).Msg("Found user")
 			return u.ID, nil
 		}
 	}
+	l.Debug().Msg("No user found")
 	return 0, ErrNotFound
 }
 

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/rs/zerolog v1.20.0
+	github.com/sqweek/dialog v0.0.0-20200911184034-8a3d98e8211d
 	github.com/stretchr/testify v1.6.1
 	github.com/zclconf/go-cty v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/rs/zerolog v1.20.0
-	github.com/sqweek/dialog v0.0.0-20200911184034-8a3d98e8211d
 	github.com/stretchr/testify v1.6.1
 	github.com/zclconf/go-cty v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 h1:1BDTz0u9nC3//pOCMdNH+CiXJVYJh5UQNCOBG7jbELc=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf h1:FPsprx82rdrX2jiKyS17BH6IrTmUBYqZa/CXT4uvb+I=
+github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -368,6 +370,8 @@ github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/spf13/pflag v1.0.2 h1:Fy0orTDgHdbnzHcsOgfCN4LtHf0ec3wwtiwJqwvf3Gc=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/sqweek/dialog v0.0.0-20200911184034-8a3d98e8211d h1:Chay1rwJnXxI27H+pzu7P81BKf647un9GOoRPTdXN18=
+github.com/sqweek/dialog v0.0.0-20200911184034-8a3d98e8211d/go.mod h1:/qNPSY91qTz/8TgHEMioAUc6q7+3SOybeKczHMXFcXw=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 h1:1BDTz0u9nC3//pOCMdNH+CiXJVYJh5UQNCOBG7jbELc=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf h1:FPsprx82rdrX2jiKyS17BH6IrTmUBYqZa/CXT4uvb+I=
-github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -242,8 +240,6 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggUE=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
-github.com/hashicorp/hcl/v2 v2.7.0 h1:IU8qz5UzZ1po3M1D9/Kq6S5zbDGVfI9bnzmC1ogKKmI=
-github.com/hashicorp/hcl/v2 v2.7.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/hcl/v2 v2.7.1 h1:eZWfKEO93WyE4OnZSD5LVy70YHDV/mmQ49gpKDLpDVM=
 github.com/hashicorp/hcl/v2 v2.7.1/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
@@ -256,8 +252,6 @@ github.com/hashicorp/terraform-plugin-go v0.1.0 h1:kyXZ0nkHxiRev/q18N40IbRRk4AV0
 github.com/hashicorp/terraform-plugin-go v0.1.0/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
 github.com/hashicorp/terraform-plugin-go v0.2.0 h1:zV9OdhCKKXem+LdNi7Vt2Znz6oeED2rI0jmfRDcWLc0=
 github.com/hashicorp/terraform-plugin-go v0.2.0/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0 h1:2m4uKA97R8ijHGLwhHdpSJyI8Op1FpS/ozpoF21jK7s=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0/go.mod h1:+12dJQebYjuU/yiq94iZUPuC66abfRBrXdpVJia3ojk=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0 h1:Egv+R1tOOjPNz643KBTx3tLT6RdFGGYJcZlyLvrPcEU=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0/go.mod h1:+12dJQebYjuU/yiq94iZUPuC66abfRBrXdpVJia3ojk=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -370,8 +364,6 @@ github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/spf13/pflag v1.0.2 h1:Fy0orTDgHdbnzHcsOgfCN4LtHf0ec3wwtiwJqwvf3Gc=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/sqweek/dialog v0.0.0-20200911184034-8a3d98e8211d h1:Chay1rwJnXxI27H+pzu7P81BKf647un9GOoRPTdXN18=
-github.com/sqweek/dialog v0.0.0-20200911184034-8a3d98e8211d/go.mod h1:/qNPSY91qTz/8TgHEMioAUc6q7+3SOybeKczHMXFcXw=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -528,10 +520,6 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201109165425-215b40eba54c h1:+B+zPA6081G5cEb2triOIJpcvSW4AYzmIyWAqMn2JAc=
-golang.org/x/sys v0.0.0-20201109165425-215b40eba54c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba h1:xmhUJGQGbxlod18iJGqVEp9cHIPLl7QiX2aA3to708s=
-golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -644,10 +632,6 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEY
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200711021454-869866162049 h1:YFTFpQhgvrLrmxtiIncJxFXeCyq84ixuKWVCaCAi9Oc=
 google.golang.org/genproto v0.0.0-20200711021454-869866162049/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb h1:MoNcrN5yaH+35Ge8RUwFbL7ekwq9ED2fiDpgWKrR29w=
-google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20201113130914-ce600e9a6f9e h1:jRAe+6EDD0LNrVzmjx7FxBivivOZTKnXMbH5lvmxLP8=
-google.golang.org/genproto v0.0.0-20201113130914-ce600e9a6f9e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 h1:Rt0FRalMgdSlXAVJvX4pr65KfqaxHXSLkSJRD9pw6g0=
 google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/rollbar/resource_user.go
+++ b/rollbar/resource_user.go
@@ -325,7 +325,16 @@ func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{
 	// If user ID is not in state, try to query it from Rollbar
 	if userID == 0 {
 		userID, err = c.FindUserID(email)
-		if err != client.ErrNotFound && err != nil {
+		switch err {
+		case nil:
+			l = log.With().
+				Str("email", email).
+				Int("userID", userID).
+				Logger()
+			l.Debug().Msg("Found registered user")
+		case client.ErrNotFound:
+			l.Debug().Msg("No registered user found")
+		default:
 			l.Err(err).Send()
 			return diag.FromErr(err)
 		}

--- a/rollbar/resource_user.go
+++ b/rollbar/resource_user.go
@@ -331,6 +331,13 @@ func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{
 		}
 	}
 
+	// If no user ID was found, user has been invited but not yet registered.
+	if userID == 0 {
+		mustSet(d, "status", "invited")
+	} else {
+		mustSet(d, "status", "registered")
+	}
+
 	currentTeams, err := resourceUserCurrentTeams(c, email, userID)
 	if err != nil {
 		l.Err(err).Send()

--- a/rollbar/resource_user_test.go
+++ b/rollbar/resource_user_test.go
@@ -780,7 +780,8 @@ func (s *AccSuite) TestAccUserInvitedToRegistered() {
 	`
 	config := fmt.Sprintf(tmpl, randString, randString)
 	var r *recorder.Recorder
-	resource.ParallelTest(s.T(), resource.TestCase{
+	origTransport := http.DefaultTransport
+	resource.Test(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
 		Providers:    s.providers,
 		CheckDestroy: nil,
@@ -832,6 +833,7 @@ func (s *AccSuite) TestAccUserInvitedToRegistered() {
 	})
 	err := r.Stop() // Stop the last recorder
 	s.Nil(err)
+	http.DefaultTransport = origTransport
 }
 
 // vcrFilterHeaders removes unnecessary headers from VCR recordings.

--- a/rollbar/resource_user_test.go
+++ b/rollbar/resource_user_test.go
@@ -840,7 +840,7 @@ func (s *AccSuite) TestAccUserInvitedToRegistered() {
 func vcrFilterHeaders(i *cassette.Interaction) error {
 	delete(i.Request.Headers, "X-Rollbar-Access-Token")
 	delete(i.Request.Headers, "User-Agent")
-	for key, _ := range i.Response.Headers {
+	for key := range i.Response.Headers {
 		deleteHeader := false
 		if strings.HasPrefix(key, "X-") {
 			deleteHeader = true

--- a/rollbar/resource_user_test.go
+++ b/rollbar/resource_user_test.go
@@ -766,16 +766,16 @@ func (s *AccSuite) checkUserIsNotInvited(userEmail, teamName string) resource.Te
 // invited to registered status.
 func (s *AccSuite) TestAccUserInvitedToRegistered() {
 	rn := "rollbar_user.test_user"
-	//randString := "t2ueouxmrx" // Must be constant across VCR record/playback runs
+	//randString := "tf-acc-test-xzdpje09gd" // Must be constant across VCR record/playback runs
 	randString := s.randName
 	// language=hcl
 	tmpl := `
 		resource "rollbar_team" "test_team" {
-			name = "tf-acc-test-%s"
+			name = "%s"
 		}
 
 		resource "rollbar_user" "test_user" {
-			email = "jason.mcvetta+tf-acc-test-%s@gmail.com"
+			email = "jason.mcvetta+%s@gmail.com"
 			team_ids = [rollbar_team.test_team.id]
 		}
 	`

--- a/rollbar/resource_user_test.go
+++ b/rollbar/resource_user_test.go
@@ -801,6 +801,11 @@ func (s *AccSuite) TestAccUserInvitedToRegistered() {
 			},
 			{
 				PreConfig: func() {
+					// When recording the cassette, we use
+					// github.com/sqweek/dialog to pop up a GUI dialog and wait
+					// for confirmation; thereby allowing the developer to
+					// manually accept the invitation.
+
 					//ok := dialog.Message(
 					//	"%s",
 					//	"Accept the email invitation then continue",
@@ -808,6 +813,7 @@ func (s *AccSuite) TestAccUserInvitedToRegistered() {
 					//if !ok {
 					//	s.FailNow("User did not accept the invitation")
 					//}
+
 					err := r.Stop() // Stop the previous recorder
 					s.Nil(err)
 					r, err = recorder.New("vcr/registered_user")

--- a/rollbar/vcr/invited_user.yaml
+++ b/rollbar/vcr/invited_user.yaml
@@ -1,0 +1,853 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"access_level":"standard","name":"tf-acc-test-7lppmg40pk"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.rollbar.com/api/1/teams
+    method: POST
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "id": 705099,
+          "account_id": 317418,
+          "name": "tf-acc-test-7lppmg40pk",
+          "access_level": "standard"
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:48 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "id": 705099,
+          "account_id": 317418,
+          "name": "tf-acc-test-7lppmg40pk",
+          "access_level": "standard"
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:48 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/users
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "users": [
+            {
+              "username": "jmcvetta",
+              "id": 238101,
+              "email": "jason.mcvetta@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-rollbar-provider",
+              "id": 246078,
+              "email": "jason.mcvetta+tf-acc-test-rollbar-provider@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-axw6qup7g2",
+              "id": 249324,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-axw6qup7g2@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-cwneey7py6",
+              "id": 249325,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-cwneey7py6@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-t2ueouxmrx",
+              "id": 249326,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-t2ueouxmrx@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-xzdpje09gd",
+              "id": 249367,
+              "email": "jason.mcvetta+tf-acc-test-xzdpje09gd@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-np8hoytr6h",
+              "id": 249368,
+              "email": "jason.mcvetta+tf-acc-test-np8hoytr6h@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-isdpm39mb7",
+              "id": 249369,
+              "email": "jason.mcvetta+tf-acc-test-isdpm39mb7@gmail.com"
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:48 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 704998,
+            "account_id": 317418,
+            "name": "a4mi14cqy9",
+            "access_level": "standard"
+          },
+          {
+            "id": 662037,
+            "account_id": 317418,
+            "name": "Everyone",
+            "access_level": "everyone"
+          },
+          {
+            "id": 662036,
+            "account_id": 317418,
+            "name": "Owners",
+            "access_level": "owner"
+          },
+          {
+            "id": 704936,
+            "account_id": 317418,
+            "name": "test-team-example",
+            "access_level": "standard"
+          },
+          {
+            "id": 705099,
+            "account_id": 317418,
+            "name": "tf-acc-test-7lppmg40pk",
+            "access_level": "standard"
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:49 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704998/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158403,
+            "from_user_id": 5325,
+            "team_id": 704998,
+            "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
+            "status": "pending",
+            "date_created": 1606562666,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:49 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704936/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158376,
+            "from_user_id": 5325,
+            "team_id": 704936,
+            "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
+            "status": "pending",
+            "date_created": 1606557362,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:49 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": []
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:49 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"email":"jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+    url: https://api.rollbar.com/api/1/team/705099/invites
+    method: POST
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "id": 158417,
+          "from_user_id": 5325,
+          "team_id": 705099,
+          "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
+          "status": "pending",
+          "date_created": 1606639370,
+          "date_redeemed": null
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:50 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 704998,
+            "account_id": 317418,
+            "name": "a4mi14cqy9",
+            "access_level": "standard"
+          },
+          {
+            "id": 662037,
+            "account_id": 317418,
+            "name": "Everyone",
+            "access_level": "everyone"
+          },
+          {
+            "id": 662036,
+            "account_id": 317418,
+            "name": "Owners",
+            "access_level": "owner"
+          },
+          {
+            "id": 704936,
+            "account_id": 317418,
+            "name": "test-team-example",
+            "access_level": "standard"
+          },
+          {
+            "id": 705099,
+            "account_id": 317418,
+            "name": "tf-acc-test-7lppmg40pk",
+            "access_level": "standard"
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:50 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704998/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158403,
+            "from_user_id": 5325,
+            "team_id": 704998,
+            "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
+            "status": "pending",
+            "date_created": 1606562666,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:50 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704936/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158376,
+            "from_user_id": 5325,
+            "team_id": 704936,
+            "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
+            "status": "pending",
+            "date_created": 1606557362,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:51 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158417,
+            "from_user_id": 5325,
+            "team_id": 705099,
+            "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
+            "status": "pending",
+            "date_created": 1606639370,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:51 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/users
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "users": [
+            {
+              "username": "jmcvetta",
+              "id": 238101,
+              "email": "jason.mcvetta@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-rollbar-provider",
+              "id": 246078,
+              "email": "jason.mcvetta+tf-acc-test-rollbar-provider@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-axw6qup7g2",
+              "id": 249324,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-axw6qup7g2@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-cwneey7py6",
+              "id": 249325,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-cwneey7py6@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-t2ueouxmrx",
+              "id": 249326,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-t2ueouxmrx@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-xzdpje09gd",
+              "id": 249367,
+              "email": "jason.mcvetta+tf-acc-test-xzdpje09gd@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-np8hoytr6h",
+              "id": 249368,
+              "email": "jason.mcvetta+tf-acc-test-np8hoytr6h@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-isdpm39mb7",
+              "id": 249369,
+              "email": "jason.mcvetta+tf-acc-test-isdpm39mb7@gmail.com"
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:51 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 704998,
+            "account_id": 317418,
+            "name": "a4mi14cqy9",
+            "access_level": "standard"
+          },
+          {
+            "id": 662037,
+            "account_id": 317418,
+            "name": "Everyone",
+            "access_level": "everyone"
+          },
+          {
+            "id": 662036,
+            "account_id": 317418,
+            "name": "Owners",
+            "access_level": "owner"
+          },
+          {
+            "id": 704936,
+            "account_id": 317418,
+            "name": "test-team-example",
+            "access_level": "standard"
+          },
+          {
+            "id": 705099,
+            "account_id": 317418,
+            "name": "tf-acc-test-7lppmg40pk",
+            "access_level": "standard"
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:51 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704998/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158403,
+            "from_user_id": 5325,
+            "team_id": 704998,
+            "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
+            "status": "pending",
+            "date_created": 1606562666,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:52 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704936/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158376,
+            "from_user_id": 5325,
+            "team_id": 704936,
+            "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
+            "status": "pending",
+            "date_created": 1606557362,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:52 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158417,
+            "from_user_id": 5325,
+            "team_id": 705099,
+            "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
+            "status": "pending",
+            "date_created": 1606639370,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:52 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "id": 705099,
+          "account_id": 317418,
+          "name": "tf-acc-test-7lppmg40pk",
+          "access_level": "standard"
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:53 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/users
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "users": [
+            {
+              "username": "jmcvetta",
+              "id": 238101,
+              "email": "jason.mcvetta@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-rollbar-provider",
+              "id": 246078,
+              "email": "jason.mcvetta+tf-acc-test-rollbar-provider@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-axw6qup7g2",
+              "id": 249324,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-axw6qup7g2@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-cwneey7py6",
+              "id": 249325,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-cwneey7py6@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-t2ueouxmrx",
+              "id": 249326,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-t2ueouxmrx@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-xzdpje09gd",
+              "id": 249367,
+              "email": "jason.mcvetta+tf-acc-test-xzdpje09gd@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-np8hoytr6h",
+              "id": 249368,
+              "email": "jason.mcvetta+tf-acc-test-np8hoytr6h@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-isdpm39mb7",
+              "id": 249369,
+              "email": "jason.mcvetta+tf-acc-test-isdpm39mb7@gmail.com"
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:53 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 704998,
+            "account_id": 317418,
+            "name": "a4mi14cqy9",
+            "access_level": "standard"
+          },
+          {
+            "id": 662037,
+            "account_id": 317418,
+            "name": "Everyone",
+            "access_level": "everyone"
+          },
+          {
+            "id": 662036,
+            "account_id": 317418,
+            "name": "Owners",
+            "access_level": "owner"
+          },
+          {
+            "id": 704936,
+            "account_id": 317418,
+            "name": "test-team-example",
+            "access_level": "standard"
+          },
+          {
+            "id": 705099,
+            "account_id": 317418,
+            "name": "tf-acc-test-7lppmg40pk",
+            "access_level": "standard"
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:53 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704998/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158403,
+            "from_user_id": 5325,
+            "team_id": 704998,
+            "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
+            "status": "pending",
+            "date_created": 1606562666,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:53 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704936/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158376,
+            "from_user_id": 5325,
+            "team_id": 704936,
+            "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
+            "status": "pending",
+            "date_created": 1606557362,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:54 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158417,
+            "from_user_id": 5325,
+            "team_id": 705099,
+            "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
+            "status": "pending",
+            "date_created": 1606639370,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:42:54 GMT
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/rollbar/vcr/registered_user.yaml
+++ b/rollbar/vcr/registered_user.yaml
@@ -1,0 +1,999 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "id": 705099,
+          "account_id": 317418,
+          "name": "tf-acc-test-7lppmg40pk",
+          "access_level": "standard"
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:27 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/users
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "users": [
+            {
+              "username": "jmcvetta",
+              "id": 238101,
+              "email": "jason.mcvetta@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-rollbar-provider",
+              "id": 246078,
+              "email": "jason.mcvetta+tf-acc-test-rollbar-provider@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-axw6qup7g2",
+              "id": 249324,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-axw6qup7g2@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-cwneey7py6",
+              "id": 249325,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-cwneey7py6@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-t2ueouxmrx",
+              "id": 249326,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-t2ueouxmrx@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-xzdpje09gd",
+              "id": 249367,
+              "email": "jason.mcvetta+tf-acc-test-xzdpje09gd@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-np8hoytr6h",
+              "id": 249368,
+              "email": "jason.mcvetta+tf-acc-test-np8hoytr6h@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-isdpm39mb7",
+              "id": 249369,
+              "email": "jason.mcvetta+tf-acc-test-isdpm39mb7@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-7lppmg40pk",
+              "id": 249370,
+              "email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com"
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:28 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/user/249370/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "teams": [
+            {
+              "access_level": "everyone",
+              "id": 662037,
+              "name": "Everyone",
+              "account_id": 317418
+            },
+            {
+              "access_level": "standard",
+              "id": 705099,
+              "name": "tf-acc-test-7lppmg40pk",
+              "account_id": 317418
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:28 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 704998,
+            "account_id": 317418,
+            "name": "a4mi14cqy9",
+            "access_level": "standard"
+          },
+          {
+            "id": 662037,
+            "account_id": 317418,
+            "name": "Everyone",
+            "access_level": "everyone"
+          },
+          {
+            "id": 662036,
+            "account_id": 317418,
+            "name": "Owners",
+            "access_level": "owner"
+          },
+          {
+            "id": 704936,
+            "account_id": 317418,
+            "name": "test-team-example",
+            "access_level": "standard"
+          },
+          {
+            "id": 705099,
+            "account_id": 317418,
+            "name": "tf-acc-test-7lppmg40pk",
+            "access_level": "standard"
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:28 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704998/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158403,
+            "from_user_id": 5325,
+            "team_id": 704998,
+            "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
+            "status": "pending",
+            "date_created": 1606562666,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:29 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704936/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158376,
+            "from_user_id": 5325,
+            "team_id": 704936,
+            "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
+            "status": "pending",
+            "date_created": 1606557362,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:29 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158417,
+            "from_user_id": 5325,
+            "team_id": 705099,
+            "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
+            "status": "accepted",
+            "date_created": 1606639370,
+            "date_redeemed": 1606639394
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:29 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "id": 705099,
+          "account_id": 317418,
+          "name": "tf-acc-test-7lppmg40pk",
+          "access_level": "standard"
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:30 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/users
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "users": [
+            {
+              "username": "jmcvetta",
+              "id": 238101,
+              "email": "jason.mcvetta@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-rollbar-provider",
+              "id": 246078,
+              "email": "jason.mcvetta+tf-acc-test-rollbar-provider@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-axw6qup7g2",
+              "id": 249324,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-axw6qup7g2@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-cwneey7py6",
+              "id": 249325,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-cwneey7py6@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-t2ueouxmrx",
+              "id": 249326,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-t2ueouxmrx@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-xzdpje09gd",
+              "id": 249367,
+              "email": "jason.mcvetta+tf-acc-test-xzdpje09gd@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-np8hoytr6h",
+              "id": 249368,
+              "email": "jason.mcvetta+tf-acc-test-np8hoytr6h@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-isdpm39mb7",
+              "id": 249369,
+              "email": "jason.mcvetta+tf-acc-test-isdpm39mb7@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-7lppmg40pk",
+              "id": 249370,
+              "email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com"
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:30 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/user/249370/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "teams": [
+            {
+              "access_level": "everyone",
+              "id": 662037,
+              "name": "Everyone",
+              "account_id": 317418
+            },
+            {
+              "access_level": "standard",
+              "id": 705099,
+              "name": "tf-acc-test-7lppmg40pk",
+              "account_id": 317418
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:30 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 704998,
+            "account_id": 317418,
+            "name": "a4mi14cqy9",
+            "access_level": "standard"
+          },
+          {
+            "id": 662037,
+            "account_id": 317418,
+            "name": "Everyone",
+            "access_level": "everyone"
+          },
+          {
+            "id": 662036,
+            "account_id": 317418,
+            "name": "Owners",
+            "access_level": "owner"
+          },
+          {
+            "id": 704936,
+            "account_id": 317418,
+            "name": "test-team-example",
+            "access_level": "standard"
+          },
+          {
+            "id": 705099,
+            "account_id": 317418,
+            "name": "tf-acc-test-7lppmg40pk",
+            "access_level": "standard"
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:31 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704998/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158403,
+            "from_user_id": 5325,
+            "team_id": 704998,
+            "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
+            "status": "pending",
+            "date_created": 1606562666,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:31 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704936/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158376,
+            "from_user_id": 5325,
+            "team_id": 704936,
+            "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
+            "status": "pending",
+            "date_created": 1606557362,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:31 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158417,
+            "from_user_id": 5325,
+            "team_id": 705099,
+            "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
+            "status": "accepted",
+            "date_created": 1606639370,
+            "date_redeemed": 1606639394
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:31 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/users
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "users": [
+            {
+              "username": "jmcvetta",
+              "id": 238101,
+              "email": "jason.mcvetta@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-rollbar-provider",
+              "id": 246078,
+              "email": "jason.mcvetta+tf-acc-test-rollbar-provider@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-axw6qup7g2",
+              "id": 249324,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-axw6qup7g2@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-cwneey7py6",
+              "id": 249325,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-cwneey7py6@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-t2ueouxmrx",
+              "id": 249326,
+              "email": "jason.mcvetta+tf-acc-test-tf-acc-test-t2ueouxmrx@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-xzdpje09gd",
+              "id": 249367,
+              "email": "jason.mcvetta+tf-acc-test-xzdpje09gd@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-np8hoytr6h",
+              "id": 249368,
+              "email": "jason.mcvetta+tf-acc-test-np8hoytr6h@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-isdpm39mb7",
+              "id": 249369,
+              "email": "jason.mcvetta+tf-acc-test-isdpm39mb7@gmail.com"
+            },
+            {
+              "username": "tf-acc-test-7lppmg40pk",
+              "id": 249370,
+              "email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com"
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:32 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/user/249370/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "teams": [
+            {
+              "access_level": "everyone",
+              "id": 662037,
+              "name": "Everyone",
+              "account_id": 317418
+            },
+            {
+              "access_level": "standard",
+              "id": 705099,
+              "name": "tf-acc-test-7lppmg40pk",
+              "account_id": 317418
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:32 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 704998,
+            "account_id": 317418,
+            "name": "a4mi14cqy9",
+            "access_level": "standard"
+          },
+          {
+            "id": 662037,
+            "account_id": 317418,
+            "name": "Everyone",
+            "access_level": "everyone"
+          },
+          {
+            "id": 662036,
+            "account_id": 317418,
+            "name": "Owners",
+            "access_level": "owner"
+          },
+          {
+            "id": 704936,
+            "account_id": 317418,
+            "name": "test-team-example",
+            "access_level": "standard"
+          },
+          {
+            "id": 705099,
+            "account_id": 317418,
+            "name": "tf-acc-test-7lppmg40pk",
+            "access_level": "standard"
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:32 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704998/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158403,
+            "from_user_id": 5325,
+            "team_id": 704998,
+            "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
+            "status": "pending",
+            "date_created": 1606562666,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:33 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704936/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158376,
+            "from_user_id": 5325,
+            "team_id": 704936,
+            "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
+            "status": "pending",
+            "date_created": 1606557362,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:33 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158417,
+            "from_user_id": 5325,
+            "team_id": 705099,
+            "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
+            "status": "accepted",
+            "date_created": 1606639370,
+            "date_redeemed": 1606639394
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:33 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/user/249370/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": {
+          "teams": [
+            {
+              "access_level": "everyone",
+              "id": 662037,
+              "name": "Everyone",
+              "account_id": 317418
+            },
+            {
+              "access_level": "standard",
+              "id": 705099,
+              "name": "tf-acc-test-7lppmg40pk",
+              "account_id": 317418
+            }
+          ]
+        }
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:33 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099/user/249370
+    method: DELETE
+  response:
+    body: |-
+      {
+        "err": 0
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:34 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/teams
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 704998,
+            "account_id": 317418,
+            "name": "a4mi14cqy9",
+            "access_level": "standard"
+          },
+          {
+            "id": 662037,
+            "account_id": 317418,
+            "name": "Everyone",
+            "access_level": "everyone"
+          },
+          {
+            "id": 662036,
+            "account_id": 317418,
+            "name": "Owners",
+            "access_level": "owner"
+          },
+          {
+            "id": 704936,
+            "account_id": 317418,
+            "name": "test-team-example",
+            "access_level": "standard"
+          },
+          {
+            "id": 705099,
+            "account_id": 317418,
+            "name": "tf-acc-test-7lppmg40pk",
+            "access_level": "standard"
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:34 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704998/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158403,
+            "from_user_id": 5325,
+            "team_id": 704998,
+            "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
+            "status": "pending",
+            "date_created": 1606562666,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:34 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/704936/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158376,
+            "from_user_id": 5325,
+            "team_id": 704936,
+            "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
+            "status": "pending",
+            "date_created": 1606557362,
+            "date_redeemed": null
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:34 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099/invites
+    method: GET
+  response:
+    body: |-
+      {
+        "err": 0,
+        "result": [
+          {
+            "id": 158417,
+            "from_user_id": 5325,
+            "team_id": 705099,
+            "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
+            "status": "accepted",
+            "date_created": 1606639370,
+            "date_redeemed": 1606639394
+          }
+        ]
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:35 GMT
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://api.rollbar.com/api/1/team/705099
+    method: DELETE
+  response:
+    body: |-
+      {
+        "err": 0
+      }
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 29 Nov 2020 08:43:35 GMT
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
This PR closes #126 by adding an acceptance test for a user going from invited status to registered status.  

Since we have not found a solution to #92, this acceptance test uses [`go-vcr`](https://github.com/dnaeon/go-vcr) to playback a recording of actual API interactions.  In the recorded session I manually accepted the emailed invitation, causing the `rollbar_user` resource to change status from `invited` to `registered`.  

Closes #92

See also #108 
