### PR TITLE
document compatibility with Terraform 0.12 or 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Status
 Requirements
 ------------
 
-- [Terraform](https://www.terraform.io/downloads.html) 0.13.x
+- [Terraform](https://www.terraform.io/downloads.html) 0.12.x or 0.13.x
 - [Go](https://golang.org/doc/install) 1.14.x
 
 


### PR DESCRIPTION
This PR updates the README to document that this provider is compatible with both Terraform 0.12 and 0.13, as demonstrated by #129 