### PR TITLE
Configurable API endpoint

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,15 +31,17 @@ import (
 	"net/http"
 )
 
-const apiUrl = "https://api.rollbar.com"
+// DefaultBaseURL is the default base URL for the Rollbar API.
+const DefaultBaseURL = "https://api.rollbar.com"
 
 // RollbarApiClient is a client for the Rollbar API.
 type RollbarApiClient struct {
-	Resty *resty.Client
+	BaseURL string // Base URL for Rollbar API
+	Resty   *resty.Client
 }
 
 // NewClient sets up a new Rollbar API client.
-func NewClient(token string) *RollbarApiClient {
+func NewClient(baseURL, token string) *RollbarApiClient {
 	log.Debug().Msg("Initializing Rollbar client")
 
 	// New Resty HTTP client
@@ -55,11 +57,19 @@ func NewClient(token string) *RollbarApiClient {
 		log.Warn().Msg("Rollbar API token not set")
 	}
 
+	// Authentication
+	if baseURL == "" {
+		log.Fatal().Msg("Rollbar API base URL not set")
+	}
+
 	// Configure Resty to use Zerolog for logging
 	r.SetLogger(restyZeroLogger{log.Logger})
 
 	// Rollbar client
-	c := RollbarApiClient{Resty: r}
+	c := RollbarApiClient{
+		Resty:   r,
+		BaseURL: baseURL,
+	}
 	return &c
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -59,7 +59,7 @@ func NewClient(baseURL, token string) *RollbarApiClient {
 
 	// Authentication
 	if baseURL == "" {
-		log.Fatal().Msg("Rollbar API base URL not set")
+		log.Error().Msg("Rollbar API base URL not set")
 	}
 
 	// Configure Resty to use Zerolog for logging

--- a/client/client_suite_test.go
+++ b/client/client_suite_test.go
@@ -87,7 +87,7 @@ func (s *Suite) SetupSuite() {
 	gofakeit.Seed(0) // Setting seed to 0 will use time.Now().UnixNano()
 
 	// Setup RollbarApiClient and enable mocking
-	c := NewClient("fakeTokenString")
+	c := NewClient(DefaultBaseURL, "fakeTokenString")
 	httpmock.ActivateNonDefault(c.Resty.GetClient())
 	s.client = c
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -25,6 +25,8 @@ package client
 import (
 	"bytes"
 	"github.com/rs/zerolog/log"
+	"io"
+	"os"
 )
 
 // TestClientNoToken checks that a warning message is logged when a
@@ -37,4 +39,17 @@ func (s *Suite) TestClientNoToken() {
 	s.NotZero(bs)
 	s.Contains(bs, "warn")
 	s.Contains(bs, "Rollbar API token not set")
+}
+
+// TestClientNoBaseURL checks that an error is logged when a RollbarApiClient is
+// initialized without an API base URL.
+func (s *Suite) TestClientNoBaseURL() {
+	var buf bytes.Buffer
+	multiWriter := io.MultiWriter(os.Stderr, &buf)
+	log.Logger = log.Logger.Output(multiWriter)
+	NewClient("", "placeholder") // Invalid base URL
+	bs := buf.String()
+	s.NotZero(bs)
+	s.Contains(bs, "error")
+	s.Contains(bs, "Rollbar API base URL not set")
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -32,7 +32,7 @@ import (
 func (s *Suite) TestClientNoToken() {
 	var buf bytes.Buffer
 	log.Logger = log.Logger.Output(&buf)
-	NewClient("") // Valid, but probably not what you want, thus warn
+	NewClient(DefaultBaseURL, "") // Valid, but probably not what you want, thus warn
 	bs := buf.String()
 	s.NotZero(bs)
 	s.Contains(bs, "warn")

--- a/client/invitation.go
+++ b/client/invitation.go
@@ -52,7 +52,7 @@ func (c *RollbarApiClient) ListInvitations(teamID int) (invs []Invitation, err e
 		}).
 		SetResult(invitationListResponse{}).
 		SetError(ErrorResult{}).
-		Get(apiUrl + pathInvitations)
+		Get(c.BaseURL + pathInvitations)
 	if err != nil {
 		l.Err(err).Msg("Error listing invitations")
 		return
@@ -123,7 +123,7 @@ func (c *RollbarApiClient) CreateInvitation(teamID int, email string) (Invitatio
 		Logger()
 	l.Debug().Msg("Creating new invitation")
 
-	u := apiUrl + pathInvitations
+	u := c.BaseURL + pathInvitations
 	var inv Invitation
 	resp, err := c.Resty.R().
 		SetPathParams(map[string]string{
@@ -156,7 +156,7 @@ func (c *RollbarApiClient) ReadInvitation(inviteID int) (inv Invitation, err err
 		Int("inviteID", inviteID).
 		Logger()
 	l.Debug().Msg("Reading invitation from Rollbar API")
-	u := apiUrl + pathInvitation
+	u := c.BaseURL + pathInvitation
 	u = strings.ReplaceAll(u, "{inviteID}", strconv.Itoa(inviteID))
 	resp, err := c.Resty.R().
 		SetResult(invitationResponse{}).
@@ -188,7 +188,7 @@ func (c *RollbarApiClient) CancelInvitation(id int) (err error) {
 	l := log.With().Int("id", id).Logger()
 	l.Debug().Msg("Canceling invitation")
 
-	u := apiUrl + pathInvitation
+	u := c.BaseURL + pathInvitation
 	resp, err := c.Resty.R().
 		SetPathParams(map[string]string{
 			"inviteID": strconv.Itoa(id),

--- a/client/invitation_test.go
+++ b/client/invitation_test.go
@@ -34,7 +34,7 @@ import (
 // TestListInvitations tests listing Rollbar team invitations.
 func (s *Suite) TestListInvitations() {
 	teamID := 572097
-	u := apiUrl + pathInvitations
+	u := s.client.BaseURL + pathInvitations
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 
 	// Success
@@ -73,7 +73,7 @@ func (s *Suite) TestListInvitations() {
 // TestListPendingInvitations tests listing pending Rollbar team invitations.
 func (s *Suite) TestListPendingInvitations() {
 	teamID := 662037
-	u := apiUrl + pathInvitations
+	u := s.client.BaseURL + pathInvitations
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 
 	// Success
@@ -104,7 +104,7 @@ func (s *Suite) TestListPendingInvitations() {
 func (s *Suite) TestCreateInvitation() {
 	teamID := 572097
 	email := "test@rollbar.com"
-	u := apiUrl + pathInvitations
+	u := s.client.BaseURL + pathInvitations
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 
 	// Success
@@ -133,7 +133,7 @@ func (s *Suite) TestCreateInvitation() {
 // TestReadInvitation tests reading a Rollbar team invitation from the API.
 func (s *Suite) TestReadInvitation() {
 	id := 153650
-	u := apiUrl + pathInvitation
+	u := s.client.BaseURL + pathInvitation
 	u = strings.ReplaceAll(u, "{inviteID}", strconv.Itoa(id))
 
 	// Success
@@ -160,7 +160,7 @@ func (s *Suite) TestReadInvitation() {
 
 func (s *Suite) TestCancelInvitation() {
 	invitationID := 153650
-	u := apiUrl + pathInvitation
+	u := s.client.BaseURL + pathInvitation
 	u = strings.ReplaceAll(u, "{inviteID}", strconv.Itoa(invitationID))
 
 	r := responderFromFixture("invitation/cancel.json", http.StatusOK)
@@ -190,7 +190,7 @@ func (s *Suite) TestFindInvitations() {
 	email := "jason.mcvetta+test10@gmail.com"
 
 	// Mock list all teams
-	u := apiUrl + pathTeamList
+	u := s.client.BaseURL + pathTeamList
 	r := responderFromFixture("team/list.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
 
@@ -198,7 +198,7 @@ func (s *Suite) TestFindInvitations() {
 	for _, teamID := range []string{"662036", "662037", "676971"} {
 		fixturePath := fmt.Sprintf("invitation/list_%s.json", teamID)
 		r = responderFromFixture(fixturePath, http.StatusOK)
-		u = strings.ReplaceAll(apiUrl+pathInvitations, "{teamID}", teamID)
+		u = strings.ReplaceAll(s.client.BaseURL+pathInvitations, "{teamID}", teamID)
 		httpmock.RegisterResponder("GET", u, r)
 	}
 
@@ -233,7 +233,7 @@ func (s *Suite) TestFindPendingInvitations() {
 	email := "jason.mcvetta+test10@gmail.com"
 
 	// Mock list all teams
-	u := apiUrl + pathTeamList
+	u := s.client.BaseURL + pathTeamList
 	r := responderFromFixture("team/list.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
 
@@ -241,7 +241,7 @@ func (s *Suite) TestFindPendingInvitations() {
 	for _, teamID := range []string{"662036", "662037", "676971"} {
 		fixturePath := fmt.Sprintf("invitation/list_%s.json", teamID)
 		r = responderFromFixture(fixturePath, http.StatusOK)
-		u = strings.ReplaceAll(apiUrl+pathInvitations, "{teamID}", teamID)
+		u = strings.ReplaceAll(s.client.BaseURL+pathInvitations, "{teamID}", teamID)
 		httpmock.RegisterResponder("GET", u, r)
 	}
 

--- a/client/logger_test.go
+++ b/client/logger_test.go
@@ -35,7 +35,7 @@ func (s *Suite) TestRestyZeroLogger() {
 
 	s.client.Resty.EnableTrace()
 
-	u := apiUrl + pathProjectList
+	u := s.client.BaseURL + pathProjectList
 
 	// Debug log
 	s.client.Resty.SetDebug(true)

--- a/client/project.go
+++ b/client/project.go
@@ -76,7 +76,7 @@ type Project struct {
 
 // ListProjects lists all Rollbar projects.
 func (c *RollbarApiClient) ListProjects() ([]Project, error) {
-	u := apiUrl + pathProjectList
+	u := c.BaseURL + pathProjectList
 
 	resp, err := c.Resty.R().
 		SetResult(projectListResponse{}).
@@ -112,7 +112,7 @@ func (c *RollbarApiClient) ListProjects() ([]Project, error) {
 
 // CreateProject creates a new Rollbar project.
 func (c *RollbarApiClient) CreateProject(name string) (*Project, error) {
-	u := apiUrl + pathProjectCreate
+	u := c.BaseURL + pathProjectCreate
 	l := log.With().
 		Str("name", name).
 		Logger()
@@ -141,7 +141,7 @@ func (c *RollbarApiClient) CreateProject(name string) (*Project, error) {
 // ReadProject a Rollbar project from the API. If no matching project is found,
 // returns error ErrNotFound.
 func (c *RollbarApiClient) ReadProject(projectID int) (*Project, error) {
-	u := apiUrl + pathProjectRead
+	u := c.BaseURL + pathProjectRead
 
 	l := log.With().
 		Int("projectID", projectID).
@@ -179,7 +179,7 @@ func (c *RollbarApiClient) ReadProject(projectID int) (*Project, error) {
 // DeleteProject deletes a Rollbar project. If no matching project is found,
 // returns error ErrNotFound.
 func (c *RollbarApiClient) DeleteProject(projectID int) error {
-	u := apiUrl + pathProjectDelete
+	u := c.BaseURL + pathProjectDelete
 	l := log.With().
 		Int("projectID", projectID).
 		Logger()

--- a/client/project_access_token.go
+++ b/client/project_access_token.go
@@ -171,7 +171,7 @@ func (c *RollbarApiClient) ListProjectAccessTokens(projectID int) ([]ProjectAcce
 		Logger()
 	l.Debug().Msg("Listing project access tokens")
 
-	u := apiUrl + pathProjectTokens
+	u := c.BaseURL + pathProjectTokens
 	resp, err := c.Resty.R().
 		SetResult(patListResponse{}).
 		SetError(ErrorResult{}).
@@ -259,7 +259,7 @@ func (c *RollbarApiClient) DeleteProjectAccessToken(projectID int, token string)
 		Logger()
 	l.Debug().Msg("Deleting project access token")
 
-	u := apiUrl + pathProjectToken
+	u := c.BaseURL + pathProjectToken
 	resp, err := c.Resty.R().
 		SetPathParams(map[string]string{
 			"projectID":   strconv.Itoa(projectID),
@@ -293,7 +293,7 @@ func (c *RollbarApiClient) CreateProjectAccessToken(args ProjectAccessTokenCreat
 		return pat, err
 	}
 
-	u := apiUrl + pathProjectTokens
+	u := c.BaseURL + pathProjectTokens
 	resp, err := c.Resty.R().
 		SetPathParams(map[string]string{
 			"projectID": strconv.Itoa(args.ProjectID),
@@ -332,7 +332,7 @@ func (c *RollbarApiClient) UpdateProjectAccessToken(args ProjectAccessTokenUpdat
 		return err
 	}
 
-	u := apiUrl + pathProjectToken
+	u := c.BaseURL + pathProjectToken
 	resp, err := c.Resty.R().
 		SetPathParams(map[string]string{
 			"projectID":   strconv.Itoa(args.ProjectID),

--- a/client/project_access_token_test.go
+++ b/client/project_access_token_test.go
@@ -34,7 +34,7 @@ import (
 // TestListProjectAccessTokens tests listing Rollbar project access tokens.
 func (s *Suite) TestListProjectAccessTokens() {
 	projectID := 12116
-	u := apiUrl + pathProjectTokens
+	u := s.client.BaseURL + pathProjectTokens
 	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(projectID))
 
 	r := responderFromFixture("project_access_token/list.json", http.StatusOK)
@@ -118,7 +118,7 @@ func (s *Suite) TestListProjectAccessTokens() {
 // the API.
 func (s *Suite) TestReadProjectAccessToken() {
 	projectID := 411334
-	u := apiUrl + pathProjectTokens
+	u := s.client.BaseURL + pathProjectTokens
 	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(projectID))
 
 	r := responderFromFixture("project_access_token/list.json", http.StatusOK)
@@ -159,7 +159,7 @@ func (s *Suite) TestReadProjectAccessToken() {
 // from the API.
 func (s *Suite) TestReadProjectAccessTokenByName() {
 	projectID := 411334
-	u := apiUrl + pathProjectTokens
+	u := s.client.BaseURL + pathProjectTokens
 	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(projectID))
 
 	r := responderFromFixture("project_access_token/list.json", http.StatusOK)
@@ -200,7 +200,7 @@ func (s *Suite) TestReadProjectAccessTokenByName() {
 func (s *Suite) TestDeleteProjectAccessToken() {
 	projectID := 428325
 	token := "bccf06c897d74020a80cb72407abb4ee"
-	u := apiUrl + pathProjectToken
+	u := s.client.BaseURL + pathProjectToken
 	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(projectID))
 	u = strings.ReplaceAll(u, "{accessToken}", token)
 
@@ -225,7 +225,7 @@ func (s *Suite) TestCreateProjectAccessToken() {
 		Scopes:    []Scope{ScopeRead, ScopeWrite},
 		Status:    StatusEnabled,
 	}
-	u := apiUrl + pathProjectTokens
+	u := s.client.BaseURL + pathProjectTokens
 	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(projID))
 	rs := responseFromFixture("project_access_token/create.json", http.StatusOK)
 	r := func(req *http.Request) (*http.Response, error) {
@@ -310,7 +310,7 @@ func (s *Suite) TestUpdateProjectAccessToken() {
 		RateLimitWindowSize:  1000,
 		RateLimitWindowCount: 2500,
 	}
-	u := apiUrl + pathProjectToken
+	u := s.client.BaseURL + pathProjectToken
 	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(projID))
 	u = strings.ReplaceAll(u, "{accessToken}", accessToken)
 	rs := responseFromFixture("project_access_token/update.json", http.StatusOK)

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func (s *Suite) TestListProjects() {
-	u := apiUrl + pathProjectList
+	u := s.client.BaseURL + pathProjectList
 
 	// Success
 	r := responderFromFixture("project/list.json", http.StatusOK)
@@ -72,7 +72,7 @@ func (s *Suite) TestListProjects() {
 }
 
 func (s *Suite) TestCreateProject() {
-	u := apiUrl + pathProjectCreate
+	u := s.client.BaseURL + pathProjectCreate
 	name := "baz"
 
 	// Success
@@ -106,7 +106,7 @@ func (s *Suite) TestReadProject() {
 		Name:         "baz",
 		Status:       "enabled",
 	}
-	u := apiUrl + pathProjectRead
+	u := s.client.BaseURL + pathProjectRead
 	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(expected.ID))
 
 	// Success
@@ -131,7 +131,7 @@ func (s *Suite) TestReadProject() {
 
 func (s *Suite) TestDeleteProject() {
 	delID := gofakeit.Number(0, 1000000)
-	urlDel := apiUrl + pathProjectDelete
+	urlDel := s.client.BaseURL + pathProjectDelete
 	urlDel = strings.ReplaceAll(urlDel, "{projectID}", strconv.Itoa(delID))
 
 	// Success
@@ -152,17 +152,17 @@ func (s *Suite) TestFindProjectTeamIDs() {
 	expected := []int{teamID}
 
 	// Mock list team projects
-	u = apiUrl + pathTeamProjects
+	u = s.client.BaseURL + pathTeamProjects
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	r = responderFromFixture("team/list_projects_689492.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
-	u = apiUrl + pathTeamProjects
+	u = s.client.BaseURL + pathTeamProjects
 	u = strings.ReplaceAll(u, "{teamID}", "689493")
 	r = responderFromFixture("team/list_projects_689493.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
 
 	// Mock list teams
-	u = apiUrl + pathTeamList
+	u = s.client.BaseURL + pathTeamList
 	r = responderFromFixture("team/list_2.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
 
@@ -203,7 +203,7 @@ func TestUpdateProjectTeams(t *testing.T) {
 		return nil
 	})
 
-	c := NewClient(os.Getenv("ROLLBAR_API_KEY"))
+	c := NewClient(DefaultBaseURL, os.Getenv("ROLLBAR_API_KEY"))
 	c.Resty.GetClient().Transport = r
 
 	prefix := "tf-acc-test-updateprojectteams"

--- a/client/team.go
+++ b/client/team.go
@@ -54,7 +54,7 @@ func (c *RollbarApiClient) CreateTeam(name string, level string) (Team, error) {
 		return t, fmt.Errorf("name cannot be blank")
 	}
 
-	u := apiUrl + pathTeamCreate
+	u := c.BaseURL + pathTeamCreate
 	resp, err := c.Resty.R().
 		SetBody(map[string]interface{}{
 			"name":         name,
@@ -84,7 +84,7 @@ func (c *RollbarApiClient) CreateTeam(name string, level string) (Team, error) {
 func (c *RollbarApiClient) ListTeams() ([]Team, error) {
 	log.Debug().Msg("Listing all teams")
 	var teams []Team
-	u := apiUrl + pathTeamList
+	u := c.BaseURL + pathTeamList
 	resp, err := c.Resty.R().
 		SetResult(teamListResponse{}).
 		SetError(ErrorResult{}).
@@ -136,7 +136,7 @@ func (c *RollbarApiClient) ReadTeam(id int) (Team, error) {
 		return t, fmt.Errorf("id must be non-zero")
 	}
 
-	u := apiUrl + pathTeamRead
+	u := c.BaseURL + pathTeamRead
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(id))
 	resp, err := c.Resty.R().
 		SetResult(teamReadResponse{}).
@@ -173,7 +173,7 @@ func (c *RollbarApiClient) DeleteTeam(id int) error {
 		return fmt.Errorf("id must be non-zero")
 	}
 
-	u := apiUrl + pathTeamDelete
+	u := c.BaseURL + pathTeamDelete
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(id))
 	resp, err := c.Resty.R().
 		SetError(ErrorResult{}).
@@ -201,7 +201,7 @@ func (c *RollbarApiClient) AssignUserToTeam(teamID, userID int) error {
 			"userID": strconv.Itoa(userID),
 		}).
 		SetError(ErrorResult{}).
-		Put(apiUrl + pathTeamUser)
+		Put(c.BaseURL + pathTeamUser)
 	if err != nil {
 		l.Err(err).Msg("Error assigning user to team")
 		return err
@@ -231,7 +231,7 @@ func (c *RollbarApiClient) RemoveUserFromTeam(userID, teamID int) error {
 			"userID": strconv.Itoa(userID),
 		}).
 		SetError(ErrorResult{}).
-		Delete(apiUrl + pathTeamUser)
+		Delete(c.BaseURL + pathTeamUser)
 	if err != nil {
 		l.Err(err).Msg("Error removing user from team")
 		return err
@@ -285,7 +285,7 @@ func (c *RollbarApiClient) ListTeamProjectIDs(teamID int) ([]int, error) {
 		}).
 		SetResult(teamProjectListResponse{}).
 		SetError(ErrorResult{}).
-		Get(apiUrl + pathTeamProjects)
+		Get(c.BaseURL + pathTeamProjects)
 	if err != nil {
 		l.Err(err).Msg("Error listing projects for team")
 		return nil, err
@@ -317,7 +317,7 @@ func (c *RollbarApiClient) AssignTeamToProject(teamID, projectID int) error {
 			"projectID": strconv.Itoa(projectID),
 		}).
 		SetError(ErrorResult{}).
-		Put(apiUrl + pathTeamProject)
+		Put(c.BaseURL + pathTeamProject)
 	if err != nil {
 		l.Err(err).Msg("Error assigning team to project")
 		return err
@@ -344,7 +344,7 @@ func (c *RollbarApiClient) RemoveTeamFromProject(teamID, projectID int) error {
 			"projectID": strconv.Itoa(projectID),
 		}).
 		SetError(ErrorResult{}).
-		Delete(apiUrl + pathTeamProject)
+		Delete(c.BaseURL + pathTeamProject)
 	if err != nil {
 		l.Err(err).Msg("Error removing team from project")
 		return err

--- a/client/team_test.go
+++ b/client/team_test.go
@@ -34,7 +34,7 @@ func (s *Suite) TestCreateTeam() {
 	// Setup API mock
 	teamName := "foobar"
 	accessLevel := "standard"
-	u := apiUrl + pathTeamCreate
+	u := s.client.BaseURL + pathTeamCreate
 	expected := Team{
 		ID:          676974,
 		AccountID:   317418,
@@ -72,7 +72,7 @@ func (s *Suite) TestCreateTeam() {
 
 func (s *Suite) TestListTeams() {
 	// Setup API mock
-	u := apiUrl + pathTeamList
+	u := s.client.BaseURL + pathTeamList
 	expected := []Team{
 		{
 			AccessLevel: "everyone",
@@ -110,7 +110,7 @@ func (s *Suite) TestListTeams() {
 func (s *Suite) TestReadTeam() {
 	// Setup API mock
 	teamID := 676974
-	u := apiUrl + pathTeamRead
+	u := s.client.BaseURL + pathTeamRead
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	expected := Team{
 		ID:          676974,
@@ -147,7 +147,7 @@ func (s *Suite) TestReadTeam() {
 func (s *Suite) TestDeleteTeam() {
 	// Setup API mock
 	teamID := 676974
-	u := apiUrl + pathTeamDelete
+	u := s.client.BaseURL + pathTeamDelete
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	r := responderFromFixture("team/delete.json", http.StatusOK)
 	httpmock.RegisterResponder("DELETE", u, r)
@@ -171,7 +171,7 @@ func (s *Suite) TestAssignUserToTeam() {
 	userID := 238101
 
 	// Successful assignment
-	u := apiUrl + pathTeamUser
+	u := s.client.BaseURL + pathTeamUser
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	u = strings.ReplaceAll(u, "{userID}", strconv.Itoa(userID))
 	r := responderFromFixture("team/assign_user.json", http.StatusOK)
@@ -185,7 +185,7 @@ func (s *Suite) TestAssignUserToTeam() {
 	})
 
 	// API returns status 403 when the team or user is not found.
-	u = apiUrl + pathTeamUser
+	u = s.client.BaseURL + pathTeamUser
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	u = strings.ReplaceAll(u, "{userID}", "0")
 	r = responderFromFixture("team/assign_user_not_found.json", http.StatusForbidden)
@@ -200,7 +200,7 @@ func (s *Suite) TestRemoveUserFromTeam() {
 	userID := 238101
 
 	// Successful assignment
-	u := apiUrl + pathTeamUser
+	u := s.client.BaseURL + pathTeamUser
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	u = strings.ReplaceAll(u, "{userID}", strconv.Itoa(userID))
 	r := responderFromFixture("team/remove_user.json", http.StatusOK)
@@ -214,7 +214,7 @@ func (s *Suite) TestRemoveUserFromTeam() {
 	})
 
 	// API returns status 422 when the team or user is not found.
-	u = apiUrl + pathTeamUser
+	u = s.client.BaseURL + pathTeamUser
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	u = strings.ReplaceAll(u, "{userID}", "0")
 	r = responderFromFixture("team/remove_user_not_found.json", http.StatusUnprocessableEntity)
@@ -225,7 +225,7 @@ func (s *Suite) TestRemoveUserFromTeam() {
 
 // TestListCustomTeams tests listing custom defined teams.
 func (s *Suite) TestListCustomTeams() {
-	u := apiUrl + pathTeamList
+	u := s.client.BaseURL + pathTeamList
 	expected := []Team{
 		{
 			ID:          676971,
@@ -249,7 +249,7 @@ func (s *Suite) TestListCustomTeams() {
 
 func (s *Suite) TestFindTeamID() {
 	expected := 676971
-	u := apiUrl + pathTeamList
+	u := s.client.BaseURL + pathTeamList
 	r := responderFromFixture("team/list.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
 
@@ -270,7 +270,7 @@ func (s *Suite) TestFindTeamID() {
 func (s *Suite) TestListTeamProjects() {
 	teamID := 689492
 	expected := []int{423092}
-	u := apiUrl + pathTeamProjects
+	u := s.client.BaseURL + pathTeamProjects
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	r := responderFromFixture("team/list_projects_689492.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
@@ -289,7 +289,7 @@ func (s *Suite) TestListTeamProjects() {
 func (s *Suite) TestAssignTeamToProject() {
 	teamID := 689492
 	projectID := 423092
-	u := apiUrl + pathTeamProject
+	u := s.client.BaseURL + pathTeamProject
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(projectID))
 	r := responderFromFixture("team/assign_project.json", http.StatusOK)
@@ -308,7 +308,7 @@ func (s *Suite) TestAssignTeamToProject() {
 func (s *Suite) TestRemoveTeamFromProject() {
 	teamID := 689492
 	projectID := 423092
-	u := apiUrl + pathTeamProject
+	u := s.client.BaseURL + pathTeamProject
 	u = strings.ReplaceAll(u, "{teamID}", strconv.Itoa(teamID))
 	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(projectID))
 	r := responderFromFixture("team/remove_project.json", http.StatusOK)

--- a/client/user.go
+++ b/client/user.go
@@ -40,7 +40,7 @@ type User struct {
 // ListUsers lists all Rollbar users.
 func (c *RollbarApiClient) ListUsers() (users []User, err error) {
 	log.Debug().Msg("Listing users")
-	u := apiUrl + pathUsers
+	u := c.BaseURL + pathUsers
 	resp, err := c.Resty.R().
 		SetResult(userListResponse{}).
 		SetError(ErrorResult{}).
@@ -66,7 +66,7 @@ func (c *RollbarApiClient) ListUsers() (users []User, err error) {
 func (c *RollbarApiClient) ReadUser(id int) (user User, err error) {
 	l := log.With().Int("id", id).Logger()
 	l.Debug().Msg("Reading user from API")
-	u := apiUrl + pathUser
+	u := c.BaseURL + pathUser
 	resp, err := c.Resty.R().
 		SetPathParams(map[string]string{"userID": strconv.Itoa(id)}).
 		SetResult(userReadResponse{}).
@@ -112,7 +112,7 @@ func (c *RollbarApiClient) FindUserID(email string) (int, error) {
 func (c *RollbarApiClient) ListUserTeams(userID int) (teams []Team, err error) {
 	l := log.With().Int("userID", userID).Logger()
 	l.Debug().Msg("Reading teams for Rollbar user")
-	u := apiUrl + pathUserTeams
+	u := c.BaseURL + pathUserTeams
 	resp, err := c.Resty.R().
 		SetPathParams(map[string]string{"userID": strconv.Itoa(userID)}).
 		SetResult(userTeamListResponse{}).

--- a/client/user_test.go
+++ b/client/user_test.go
@@ -31,7 +31,7 @@ import (
 
 // TestListUsers tests listing all Rollbar users.
 func (s *Suite) TestListUsers() {
-	u := apiUrl + pathUsers
+	u := s.client.BaseURL + pathUsers
 
 	// Success
 	r := responderFromFixture("user/list.json", http.StatusOK)
@@ -62,7 +62,7 @@ func (s *Suite) TestListUsers() {
 // TestReadUser tests reading a Rollbar user from the API.
 func (s *Suite) TestReadUser() {
 	userID := 238101
-	u := apiUrl + pathUser
+	u := s.client.BaseURL + pathUser
 	u = strings.ReplaceAll(u, "{userID}", strconv.Itoa(userID))
 
 	// Success
@@ -90,7 +90,7 @@ func (s *Suite) TestUserIDFromEmail() {
 	email := "jason.mcvetta@gmail.com"
 	expected := 238101
 
-	u := apiUrl + pathUsers
+	u := s.client.BaseURL + pathUsers
 	r := responderFromFixture("user/list.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
 
@@ -110,7 +110,7 @@ func (s *Suite) TestUserIDFromEmail() {
 // TestListUserTeams tests listing all teams for a Rollbar user.
 func (s *Suite) TestListUserTeams() {
 	userID := 238101
-	u := apiUrl + pathUserTeams
+	u := s.client.BaseURL + pathUserTeams
 	u = strings.ReplaceAll(u, "{userID}", strconv.Itoa(userID))
 
 	// Success
@@ -150,7 +150,7 @@ func (s *Suite) TestListUserTeams() {
 // TestListUserTeams tests listing custom defined teams for a Rollbar user.
 func (s *Suite) TestListUserCustomTeams() {
 	userID := 238101
-	u := apiUrl + pathUserTeams
+	u := s.client.BaseURL + pathUserTeams
 	u = strings.ReplaceAll(u, "{userID}", strconv.Itoa(userID))
 
 	// Success

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,11 @@ Argument Reference
 
 The following arguments are supported:
 
-* `api_key` - (Required) This is the Rollbar authentication token. The value can
-  be sourced from the ROLLBAR_TOKEN environment variable.
+* `api_key` - (Required) Rollbar API authentication token. Value will be
+  sourced from environment variable `ROLLBAR_API_KEY` if set.
+* `api_url` - (Optional) Base URL for the Rollbar API.  Defaults to
+  https://api.rollbar.com.  Value will be sourced from environment variable
+  `ROLLBAR_API_URL` if set.
 
 
 Data Sources

--- a/rollbar/provider.go
+++ b/rollbar/provider.go
@@ -38,17 +38,21 @@ import (
 )
 
 const schemaKeyToken = "api_key"
+const schemaKeyBaseURL = "base_url"
 
 // Provider is a Terraform provider for Rollbar.
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			schemaKeyToken: {
-				Type:     schema.TypeString,
-				Optional: true,
-				// FIXME: Should the environment variable be ROLLBAR_API_KEY to
-				//  match the name of this field?
+				Type:        schema.TypeString,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ROLLBAR_API_KEY", nil),
+			},
+			schemaKeyBaseURL: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ROLLBAR_API_URL", client.DefaultBaseURL),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -71,7 +75,8 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	token := d.Get(schemaKeyToken).(string)
-	c := client.NewClient(token)
+	baseURL := d.Get(schemaKeyBaseURL).(string)
+	c := client.NewClient(baseURL, token)
 	return c, diags
 }
 

--- a/rollbar/provider.go
+++ b/rollbar/provider.go
@@ -38,7 +38,7 @@ import (
 )
 
 const schemaKeyToken = "api_key"
-const schemaKeyBaseURL = "base_url"
+const schemaKeyBaseURL = "api_url"
 
 // Provider is a Terraform provider for Rollbar.
 func Provider() *schema.Provider {

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -282,7 +282,7 @@ func (s *AccSuite) checkProjectInProjectList(rn string) resource.TestCheckFunc {
 func sweepResourceProject(_ string) error {
 	log.Info().Msg("Cleaning up Rollbar projects from acceptance test runs.")
 
-	c := client.NewClient(os.Getenv("ROLLBAR_API_KEY"))
+	c := client.NewClient(client.DefaultBaseURL, os.Getenv("ROLLBAR_API_KEY"))
 	projects, err := c.ListProjects()
 	if err != nil {
 		log.Err(err).Send()

--- a/rollbar/resource_team_test.go
+++ b/rollbar/resource_team_test.go
@@ -214,7 +214,7 @@ func (s *AccSuite) DontTestAccTeamDeleteOnAPIBeforeApply() {
 			// Before running Terraform, delete the team on Rollbar but not in local state
 			{
 				PreConfig: func() {
-					c := client.NewClient(os.Getenv("ROLLBAR_API_KEY"))
+					c := client.NewClient(client.DefaultBaseURL, os.Getenv("ROLLBAR_API_KEY"))
 					teams, err := c.ListCustomTeams()
 					s.Nil(err)
 					for _, t := range teams {
@@ -258,7 +258,7 @@ func (s *AccSuite) checkTeam(rn, teamName, accessLevel string) resource.TestChec
 func sweepResourceTeam(_ string) error {
 	log.Info().Msg("Cleaning up Rollbar teams from acceptance test runs.")
 
-	c := client.NewClient(os.Getenv("ROLLBAR_API_KEY"))
+	c := client.NewClient(client.DefaultBaseURL, os.Getenv("ROLLBAR_API_KEY"))
 	teams, err := c.ListCustomTeams()
 	if err != nil {
 		log.Err(err).Send()

--- a/rollbar/resource_user_test.go
+++ b/rollbar/resource_user_test.go
@@ -871,7 +871,7 @@ func vcrFilterHeaders(i *cassette.Interaction) error {
 func sweepResourceUser(_ string) error {
 	log.Info().Msg("Cleaning up Rollbar users from acceptance test runs.")
 
-	c := client.NewClient(os.Getenv("ROLLBAR_API_KEY"))
+	c := client.NewClient(client.DefaultBaseURL, os.Getenv("ROLLBAR_API_KEY"))
 	users, err := c.ListUsers()
 	if err != nil {
 		log.Err(err).Send()


### PR DESCRIPTION
This PR closes #148 by making Rollbar API base URL optionally configurable, using either provider argument `api_url` or environment variable `ROLLBAR_API_URL`.