### PR TITLE
Fix `TestAccTeamDeleteOnAPIBeforeApply`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 	"net/http"
+	"strings"
 )
 
 // DefaultBaseURL is the default base URL for the Rollbar API.
@@ -88,6 +89,20 @@ func errorFromResponse(resp *resty.Response) error {
 	switch resp.StatusCode() {
 	case http.StatusOK, http.StatusCreated:
 		return nil
+	case http.StatusForbidden:
+		// Workaround for known API bug:
+		// https://github.com/rollbar/terraform-provider-rollbar/issues/79
+		er := resp.Error().(*ErrorResult)
+		if strings.Contains(er.Message, "not found in this account") {
+			log.Debug().
+				Str("status", resp.Status()).
+				Int("status_code", resp.StatusCode()).
+				Str("error_message", er.Message).
+				Int("error_code", er.Err).
+				Msg("Workaround entity not found API bug")
+			return ErrNotFound
+		}
+		fallthrough
 	case http.StatusUnauthorized:
 		return ErrUnauthorized
 	case http.StatusNotFound:

--- a/client/invitation.go
+++ b/client/invitation.go
@@ -57,7 +57,7 @@ func (c *RollbarApiClient) ListInvitations(teamID int) (invs []Invitation, err e
 		l.Err(err).Msg("Error listing invitations")
 		return
 	}
-	err = teamNotFoundErrFromResponse(resp)
+	err = errorFromResponse(resp)
 	if err != nil {
 		l.Err(err).
 			Str("status", resp.Status()).
@@ -139,7 +139,7 @@ func (c *RollbarApiClient) CreateInvitation(teamID int, email string) (Invitatio
 		l.Err(err).Msg("Error creating invitation")
 		return inv, err
 	}
-	err = teamNotFoundErrFromResponse(resp)
+	err = errorFromResponse(resp)
 	if err != nil {
 		l.Err(err).Send()
 		return inv, err

--- a/rollbar/provider.go
+++ b/rollbar/provider.go
@@ -27,14 +27,11 @@ package rollbar
 
 import (
 	"context"
-	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rollbar/terraform-provider-rollbar/client"
-	"github.com/rs/zerolog/log"
 	"strconv"
-	"strings"
 )
 
 const schemaKeyToken = "api_key"
@@ -78,25 +75,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	baseURL := d.Get(schemaKeyBaseURL).(string)
 	c := client.NewClient(baseURL, token)
 	return c, diags
-}
-
-// handleErrNotFound handles an ErrNotFound when reading a resource, by removing
-// the resource from state and returning a Diagnostics object. Argument
-// `detailResourceType` is the human readable name for this resource type that
-// was not found, used when constructing diagnostic messages.
-func handleErrNotFound(d *schema.ResourceData, detailResourceType string) diag.Diagnostics {
-	id := d.Id()
-	d.SetId("")
-	tmpl := `Removing %s %s from state because it was not found on Rollbar`
-	detail := fmt.Sprintf(tmpl, detailResourceType, id)
-	log.Warn().Msg(detail)
-	tmpl = "%s not found, removed from state"
-	summary := fmt.Sprintf(tmpl, strings.ToTitle(detailResourceType))
-	return diag.Diagnostics{{
-		Severity: diag.Warning,
-		Summary:  summary,
-		Detail:   detail,
-	}}
 }
 
 /*

--- a/rollbar/provider.go
+++ b/rollbar/provider.go
@@ -81,15 +81,17 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 }
 
 // handleErrNotFound handles an ErrNotFound when reading a resource, by removing
-// the resource from state and returning a Diagnostics object.
-func handleErrNotFound(d *schema.ResourceData, resourceName string) diag.Diagnostics {
+// the resource from state and returning a Diagnostics object. Argument
+// `detailResourceType` is the human readable name for this resource type that
+// was not found, used when constructing diagnostic messages.
+func handleErrNotFound(d *schema.ResourceData, detailResourceType string) diag.Diagnostics {
 	id := d.Id()
 	d.SetId("")
 	tmpl := `Removing %s %s from state because it was not found on Rollbar`
-	detail := fmt.Sprintf(tmpl, resourceName, id)
+	detail := fmt.Sprintf(tmpl, detailResourceType, id)
 	log.Warn().Msg(detail)
 	tmpl = "%s not found, removed from state"
-	summary := fmt.Sprintf(tmpl, strings.ToTitle(resourceName))
+	summary := fmt.Sprintf(tmpl, strings.ToTitle(detailResourceType))
 	return diag.Diagnostics{{
 		Severity: diag.Warning,
 		Summary:  summary,

--- a/rollbar/resource_project.go
+++ b/rollbar/resource_project.go
@@ -163,7 +163,9 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 	c := m.(*client.RollbarApiClient)
 	proj, err := c.ReadProject(projectID)
 	if err == client.ErrNotFound {
-		return handleErrNotFound(d, "project")
+		l.Debug().Msg("Project not found on Rollbar - removing from state")
+		d.SetId("")
+		return nil
 	}
 	if err != nil {
 		l.Err(err).Send()

--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -170,7 +170,9 @@ func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData,
 	c := m.(*client.RollbarApiClient)
 	pat, err := c.ReadProjectAccessToken(projectID, accessToken)
 	if err == client.ErrNotFound {
-		return handleErrNotFound(d, "project access token")
+		d.SetId("")
+		l.Debug().Msg("Token not found on Rollbar - removed from state")
+		return nil
 	}
 	if err != nil {
 		return diag.FromErr(err)

--- a/rollbar/resource_project_access_token_test.go
+++ b/rollbar/resource_project_access_token_test.go
@@ -368,7 +368,10 @@ func (s *AccSuite) TestAccTokenCreateWithNonExistentProjectID() {
 	})
 }
 
-func (s *AccSuite) TestAccTokaneDeleteOnAPIBeforeApply() {
+// TestAccTokenDeleteOnAPIBeforeApply tests creating a Rollbar project access
+// token with Terraform; then deleting it via API, before re-applying Terraform
+// configuration.
+func (s *AccSuite) TestAccTokenDeleteOnAPIBeforeApply() {
 	projectResourceName := "rollbar_project.test"
 	tokenResourceName := "rollbar_project_access_token.test"
 	// language=hcl

--- a/rollbar/resource_project_access_token_test.go
+++ b/rollbar/resource_project_access_token_test.go
@@ -374,6 +374,12 @@ func (s *AccSuite) TestAccTokenCreateWithNonExistentProjectID() {
 func (s *AccSuite) TestAccTokenDeleteOnAPIBeforeApply() {
 	projectResourceName := "rollbar_project.test"
 	tokenResourceName := "rollbar_project_access_token.test"
+	// FIXME: Why does adding this suffix to s.randName make this test pass,
+	//  while using bare s.randName causes failure?  Could it be a Testify
+	//  issue, where s.randName is not actually unique for each test in the
+	//  suite?
+	//  https://github.com/rollbar/terraform-provider-rollbar/issues/160
+	projectName := s.randName + "-0"
 	// language=hcl
 	tmpl := `
 		resource "rollbar_project" "test" {
@@ -387,7 +393,7 @@ func (s *AccSuite) TestAccTokenDeleteOnAPIBeforeApply() {
 			status = "enabled"
 		}
 	`
-	config := fmt.Sprintf(tmpl, s.randName)
+	config := fmt.Sprintf(tmpl, projectName)
 	resource.ParallelTest(s.T(), resource.TestCase{
 		PreCheck:     func() { s.preCheck() },
 		Providers:    s.providers,
@@ -405,11 +411,11 @@ func (s *AccSuite) TestAccTokenDeleteOnAPIBeforeApply() {
 					projects, err := c.ListProjects()
 					s.Nil(err)
 					for _, p := range projects {
-						if p.Name == s.randName {
+						if p.Name == projectName {
 							projectID = p.ID
 						}
 					}
-					s.NotNil(projectID)
+					s.NotZero(projectID)
 					tokens, err := c.ListProjectAccessTokens(projectID)
 					s.Nil(err)
 					for _, t := range tokens {

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -230,6 +230,9 @@ func (s *AccSuite) TestAccProjectRemoveTeam() {
 	})
 }
 
+// TestAccProjectDeleteOnAPIBeforeApply tests creating a Rollbar project with
+// Terraform; then deleting the project via API before re-applying Terraform
+// configuration.
 func (s *AccSuite) TestAccProjectDeleteOnAPIBeforeApply() {
 	rn := "rollbar_project.test"
 	// language=hcl
@@ -255,13 +258,13 @@ func (s *AccSuite) TestAccProjectDeleteOnAPIBeforeApply() {
 					c := client.NewClient(client.DefaultBaseURL, os.Getenv("ROLLBAR_API_KEY"))
 					projects, err := c.ListProjects()
 					s.Nil(err)
-					for _, t := range projects {
-						if t.Name == s.randName {
-							err = c.DeleteProject(t.ID)
+					for _, p := range projects {
+						if p.Name == s.randName {
+							err = c.DeleteProject(p.ID)
 							s.Nil(err)
 							log.Info().
 								Str("project_name", s.randName).
-								Int("project_id", t.ID).
+								Int("project_id", p.ID).
 								Msg("Deleted project from API before re-applying Terraform config")
 						}
 					}

--- a/rollbar/resource_team.go
+++ b/rollbar/resource_team.go
@@ -95,8 +95,9 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	c := m.(*client.RollbarApiClient)
 	t, err := c.ReadTeam(id)
 	if err == client.ErrNotFound {
-		l.Err(err).Send()
-		return handleErrNotFound(d, "team")
+		d.SetId("")
+		l.Err(err).Msg("Team not found - removed from state")
+		return nil
 	}
 	if err != nil {
 		l.Err(err).Msg("error reading rollbar_team resource")

--- a/rollbar/resource_team_test.go
+++ b/rollbar/resource_team_test.go
@@ -191,7 +191,7 @@ func (s *AccSuite) TestAccTeamImport() {
 // config.
 // FIXME: This code used to pass reliably, but no longer does.   Why?
 //  https://github.com/rollbar/terraform-provider-rollbar/issues/154
-func (s *AccSuite) DontTestAccTeamDeleteOnAPIBeforeApply() {
+func (s *AccSuite) TestAccTeamDeleteOnAPIBeforeApply() {
 	rn := "rollbar_team.test"
 	teamName1 := fmt.Sprintf("%s-team-1", s.randName)
 	// language=hcl

--- a/rollbar/resource_team_test.go
+++ b/rollbar/resource_team_test.go
@@ -219,20 +219,20 @@ func (s *AccSuite) TestAccTeamDeleteOnAPIBeforeApply() {
 					s.Nil(err)
 					for _, t := range teams {
 						if t.Name == teamName1 {
+							err = c.DeleteTeam(t.ID)
+							s.Nil(err)
 							log.Info().
 								Str("team_name", teamName1).
 								Int("team_id", t.ID).
-								Msg("Deleting team from API before re-applying Terraform config")
-							err = c.DeleteTeam(t.ID)
-							s.Nil(err)
+								Msg("Deleted team from API before re-applying Terraform config")
 						}
 					}
 				},
 				Config: config1,
 				Check: resource.ComposeTestCheckFunc(
 					s.checkResourceStateSanity(rn),
-					resource.TestCheckResourceAttr(rn, "name", teamName1),
 					s.checkTeam(rn, teamName1, "standard"),
+					resource.TestCheckResourceAttr(rn, "name", teamName1),
 				),
 			},
 		},


### PR DESCRIPTION
This PR closes #154 by working around the API bug described in #66, which covered more cases than previously believed.