### PR TITLE
Rename `RollbarApiClient` to `RollbarAPIClient`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -35,14 +35,14 @@ import (
 // DefaultBaseURL is the default base URL for the Rollbar API.
 const DefaultBaseURL = "https://api.rollbar.com"
 
-// RollbarApiClient is a client for the Rollbar API.
-type RollbarApiClient struct {
+// RollbarAPIClient is a client for the Rollbar API.
+type RollbarAPIClient struct {
 	BaseURL string // Base URL for Rollbar API
 	Resty   *resty.Client
 }
 
 // NewClient sets up a new Rollbar API client.
-func NewClient(baseURL, token string) *RollbarApiClient {
+func NewClient(baseURL, token string) *RollbarAPIClient {
 	log.Debug().Msg("Initializing Rollbar client")
 
 	// New Resty HTTP client
@@ -67,7 +67,7 @@ func NewClient(baseURL, token string) *RollbarApiClient {
 	r.SetLogger(restyZeroLogger{log.Logger})
 
 	// Rollbar client
-	c := RollbarApiClient{
+	c := RollbarAPIClient{
 		Resty:   r,
 		BaseURL: baseURL,
 	}

--- a/client/client_suite_test.go
+++ b/client/client_suite_test.go
@@ -72,7 +72,7 @@ func responderFromFixture(fixturePath string, status int) httpmock.Responder {
 // Suite is a Testify test suite for the Rollbar API client
 type Suite struct {
 	suite.Suite
-	client *RollbarApiClient
+	client *RollbarAPIClient
 }
 
 func (s *Suite) SetupSuite() {
@@ -86,7 +86,7 @@ func (s *Suite) SetupSuite() {
 	// Seed gofakeit random generator
 	gofakeit.Seed(0) // Setting seed to 0 will use time.Now().UnixNano()
 
-	// Setup RollbarApiClient and enable mocking
+	// Setup RollbarAPIClient and enable mocking
 	c := NewClient(DefaultBaseURL, "fakeTokenString")
 	httpmock.ActivateNonDefault(c.Resty.GetClient())
 	s.client = c

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 // TestClientNoToken checks that a warning message is logged when a
-// RollbarApiClient is initialized without an API token.
+// RollbarAPIClient is initialized without an API token.
 func (s *Suite) TestClientNoToken() {
 	var buf bytes.Buffer
 	log.Logger = log.Logger.Output(&buf)
@@ -41,7 +41,7 @@ func (s *Suite) TestClientNoToken() {
 	s.Contains(bs, "Rollbar API token not set")
 }
 
-// TestClientNoBaseURL checks that an error is logged when a RollbarApiClient is
+// TestClientNoBaseURL checks that an error is logged when a RollbarAPIClient is
 // initialized without an API base URL.
 func (s *Suite) TestClientNoBaseURL() {
 	var buf bytes.Buffer

--- a/client/invitation.go
+++ b/client/invitation.go
@@ -41,7 +41,7 @@ type Invitation struct {
 }
 
 // ListInvitations lists all invitations for a Rollbar team.
-func (c *RollbarApiClient) ListInvitations(teamID int) (invs []Invitation, err error) {
+func (c *RollbarAPIClient) ListInvitations(teamID int) (invs []Invitation, err error) {
 	l := log.With().
 		Int("teamID", teamID).
 		Logger()
@@ -73,7 +73,7 @@ func (c *RollbarApiClient) ListInvitations(teamID int) (invs []Invitation, err e
 }
 
 // ListPendingInvitations lists a Rollbar team's pending invitations.
-func (c *RollbarApiClient) ListPendingInvitations(teamID int) ([]Invitation, error) {
+func (c *RollbarAPIClient) ListPendingInvitations(teamID int) ([]Invitation, error) {
 	l := log.With().Int("teamID", teamID).Logger()
 	l.Debug().Msg("Listing pending invitations")
 	var pending []Invitation
@@ -95,7 +95,7 @@ func (c *RollbarApiClient) ListPendingInvitations(teamID int) ([]Invitation, err
 
 // FindPendingInvitations finds pending Rollbar team invitations for the given
 // email.
-func (c *RollbarApiClient) FindPendingInvitations(email string) ([]Invitation, error) {
+func (c *RollbarAPIClient) FindPendingInvitations(email string) ([]Invitation, error) {
 	l := log.With().Str("email", email).Logger()
 	l.Debug().Msg("Finding pending invitations")
 	var pending []Invitation
@@ -116,7 +116,7 @@ func (c *RollbarApiClient) FindPendingInvitations(email string) ([]Invitation, e
 }
 
 // CreateInvitation sends a Rollbar team invitation to a user.
-func (c *RollbarApiClient) CreateInvitation(teamID int, email string) (Invitation, error) {
+func (c *RollbarAPIClient) CreateInvitation(teamID int, email string) (Invitation, error) {
 	l := log.With().
 		Int("teamID", teamID).
 		Str("email", email).
@@ -151,7 +151,7 @@ func (c *RollbarApiClient) CreateInvitation(teamID int, email string) (Invitatio
 }
 
 // ReadInvitation reads a Rollbar team invitation from the API.
-func (c *RollbarApiClient) ReadInvitation(inviteID int) (inv Invitation, err error) {
+func (c *RollbarAPIClient) ReadInvitation(inviteID int) (inv Invitation, err error) {
 	l := log.With().
 		Int("inviteID", inviteID).
 		Logger()
@@ -179,12 +179,12 @@ func (c *RollbarApiClient) ReadInvitation(inviteID int) (inv Invitation, err err
 }
 
 // DeleteInvitation is an alias for CancelInvitation.
-func (c *RollbarApiClient) DeleteInvitation(id int) (err error) {
+func (c *RollbarAPIClient) DeleteInvitation(id int) (err error) {
 	return c.CancelInvitation(id)
 }
 
 // CancelInvitation cancels a Rollbar team invitation.
-func (c *RollbarApiClient) CancelInvitation(id int) (err error) {
+func (c *RollbarAPIClient) CancelInvitation(id int) (err error) {
 	l := log.With().Int("id", id).Logger()
 	l.Debug().Msg("Canceling invitation")
 
@@ -224,7 +224,7 @@ func (c *RollbarApiClient) CancelInvitation(id int) (err error) {
 // FindInvitations finds all Rollbar team invitations for a given email. Note
 // this method is quite inefficient, as it must read all invitations for all
 // teams.
-func (c *RollbarApiClient) FindInvitations(email string) (invs []Invitation, err error) {
+func (c *RollbarAPIClient) FindInvitations(email string) (invs []Invitation, err error) {
 	// API converts all invited emails to lowercase.
 	// https://github.com/rollbar/terraform-provider-rollbar/issues/139
 	email = strings.ToLower(email)

--- a/client/project.go
+++ b/client/project.go
@@ -75,7 +75,7 @@ type Project struct {
 */
 
 // ListProjects lists all Rollbar projects.
-func (c *RollbarApiClient) ListProjects() ([]Project, error) {
+func (c *RollbarAPIClient) ListProjects() ([]Project, error) {
 	u := c.BaseURL + pathProjectList
 
 	resp, err := c.Resty.R().
@@ -111,7 +111,7 @@ func (c *RollbarApiClient) ListProjects() ([]Project, error) {
 }
 
 // CreateProject creates a new Rollbar project.
-func (c *RollbarApiClient) CreateProject(name string) (*Project, error) {
+func (c *RollbarAPIClient) CreateProject(name string) (*Project, error) {
 	u := c.BaseURL + pathProjectCreate
 	l := log.With().
 		Str("name", name).
@@ -140,7 +140,7 @@ func (c *RollbarApiClient) CreateProject(name string) (*Project, error) {
 
 // ReadProject a Rollbar project from the API. If no matching project is found,
 // returns error ErrNotFound.
-func (c *RollbarApiClient) ReadProject(projectID int) (*Project, error) {
+func (c *RollbarAPIClient) ReadProject(projectID int) (*Project, error) {
 	u := c.BaseURL + pathProjectRead
 
 	l := log.With().
@@ -178,7 +178,7 @@ func (c *RollbarApiClient) ReadProject(projectID int) (*Project, error) {
 
 // DeleteProject deletes a Rollbar project. If no matching project is found,
 // returns error ErrNotFound.
-func (c *RollbarApiClient) DeleteProject(projectID int) error {
+func (c *RollbarAPIClient) DeleteProject(projectID int) error {
 	u := c.BaseURL + pathProjectDelete
 	l := log.With().
 		Int("projectID", projectID).
@@ -207,7 +207,7 @@ func (c *RollbarApiClient) DeleteProject(projectID int) error {
 // FindProjectTeamIDs finds IDs of all teams assigned to the project. Caution:
 // this is a potentially slow operation that makes multiple calls to the API.
 // https://github.com/rollbar/terraform-provider-rollbar/issues/104
-func (c *RollbarApiClient) FindProjectTeamIDs(projectID int) ([]int, error) {
+func (c *RollbarAPIClient) FindProjectTeamIDs(projectID int) ([]int, error) {
 	l := log.With().Int("project_id", projectID).Logger()
 	l.Debug().Msg("Finding teams assigned to project")
 	var projectTeamIDs []int
@@ -241,7 +241,7 @@ func (c *RollbarApiClient) FindProjectTeamIDs(projectID int) ([]int, error) {
 // and removing teams as necessary. Caution: this is a potentially slow
 // operation that makes multiple calls to the API.
 // https://github.com/rollbar/terraform-provider-rollbar/issues/104
-func (c *RollbarApiClient) UpdateProjectTeams(projectID int, teamIDs []int) error {
+func (c *RollbarAPIClient) UpdateProjectTeams(projectID int, teamIDs []int) error {
 	l := log.With().
 		Int("project_id", projectID).
 		Ints("team_ids", teamIDs).

--- a/client/project_access_token.go
+++ b/client/project_access_token.go
@@ -165,7 +165,7 @@ func (args *ProjectAccessTokenUpdateArgs) sanityCheck() error {
 
 // ListProjectAccessTokens lists the Rollbar project access tokens for the
 // specified Rollbar project.
-func (c *RollbarApiClient) ListProjectAccessTokens(projectID int) ([]ProjectAccessToken, error) {
+func (c *RollbarAPIClient) ListProjectAccessTokens(projectID int) ([]ProjectAccessToken, error) {
 	l := log.With().
 		Int("projectID", projectID).
 		Logger()
@@ -195,7 +195,7 @@ func (c *RollbarApiClient) ListProjectAccessTokens(projectID int) ([]ProjectAcce
 // ReadProjectAccessToken reads a Rollbar project access token from the API.  It
 // returns the first token that matches `name`. If no matching token is found,
 // returns error ErrNotFound.
-func (c *RollbarApiClient) ReadProjectAccessToken(projectID int, token string) (ProjectAccessToken, error) {
+func (c *RollbarAPIClient) ReadProjectAccessToken(projectID int, token string) (ProjectAccessToken, error) {
 	l := log.With().
 		Int("projectID", projectID).
 		Str("token", token).
@@ -226,7 +226,7 @@ func (c *RollbarApiClient) ReadProjectAccessToken(projectID int, token string) (
 // ReadProjectAccessTokenByName reads a Rollbar project access token from the
 // API.  It returns the first token that matches `name`. If no matching token is
 // found, returns error ErrNotFound.
-func (c *RollbarApiClient) ReadProjectAccessTokenByName(projectID int, name string) (ProjectAccessToken, error) {
+func (c *RollbarAPIClient) ReadProjectAccessTokenByName(projectID int, name string) (ProjectAccessToken, error) {
 	l := log.With().
 		Int("projectID", projectID).
 		Str("name", name).
@@ -252,7 +252,7 @@ func (c *RollbarApiClient) ReadProjectAccessTokenByName(projectID int, name stri
 	return pat, ErrNotFound
 }
 
-func (c *RollbarApiClient) DeleteProjectAccessToken(projectID int, token string) error {
+func (c *RollbarAPIClient) DeleteProjectAccessToken(projectID int, token string) error {
 	l := log.With().
 		Int("projectID", projectID).
 		Str("token", token).
@@ -280,7 +280,7 @@ func (c *RollbarApiClient) DeleteProjectAccessToken(projectID int, token string)
 }
 
 // CreateProjectAccessToken creates a Rollbar project access token.
-func (c *RollbarApiClient) CreateProjectAccessToken(args ProjectAccessTokenCreateArgs) (ProjectAccessToken, error) {
+func (c *RollbarAPIClient) CreateProjectAccessToken(args ProjectAccessTokenCreateArgs) (ProjectAccessToken, error) {
 	l := log.With().
 		Interface("args", args).
 		Logger()
@@ -320,7 +320,7 @@ func (c *RollbarApiClient) CreateProjectAccessToken(args ProjectAccessTokenCreat
 }
 
 // UpdateProjectAccessToken updates a Rollbar project access token.
-func (c *RollbarApiClient) UpdateProjectAccessToken(args ProjectAccessTokenUpdateArgs) error {
+func (c *RollbarAPIClient) UpdateProjectAccessToken(args ProjectAccessTokenUpdateArgs) error {
 	l := log.With().
 		Interface("args", args).
 		Logger()

--- a/client/team.go
+++ b/client/team.go
@@ -39,7 +39,7 @@ type Team struct {
 }
 
 // CreateTeam creates a new Rollbar team.
-func (c *RollbarApiClient) CreateTeam(name string, level string) (Team, error) {
+func (c *RollbarAPIClient) CreateTeam(name string, level string) (Team, error) {
 	var t Team
 	l := log.With().
 		Str("name", name).
@@ -80,7 +80,7 @@ func (c *RollbarApiClient) CreateTeam(name string, level string) (Team, error) {
 }
 
 // ListTeams lists all Rollbar teams.
-func (c *RollbarApiClient) ListTeams() ([]Team, error) {
+func (c *RollbarAPIClient) ListTeams() ([]Team, error) {
 	log.Debug().Msg("Listing all teams")
 	var teams []Team
 	u := c.BaseURL + pathTeamList
@@ -107,7 +107,7 @@ func (c *RollbarApiClient) ListTeams() ([]Team, error) {
 // ListCustomTeams lists all custom defined teams, excluding system teams
 // "Everyone" and "Owners".
 // FIXME: This function needs a better name.
-func (c *RollbarApiClient) ListCustomTeams() ([]Team, error) {
+func (c *RollbarAPIClient) ListCustomTeams() ([]Team, error) {
 	log.Debug().Msg("Listing custom teams")
 	var customTeams []Team
 	allTeams, err := c.ListTeams()
@@ -123,7 +123,7 @@ func (c *RollbarApiClient) ListCustomTeams() ([]Team, error) {
 
 // ReadTeam reads a Rollbar team from the API. If no matching team is found,
 // returns error ErrNotFound.
-func (c *RollbarApiClient) ReadTeam(id int) (Team, error) {
+func (c *RollbarAPIClient) ReadTeam(id int) (Team, error) {
 	var t Team
 	l := log.With().
 		Int("id", id).
@@ -161,7 +161,7 @@ func (c *RollbarApiClient) ReadTeam(id int) (Team, error) {
 
 // DeleteTeam deletes a Rollbar team. If no matching team is found, returns
 // error ErrNotFound.
-func (c *RollbarApiClient) DeleteTeam(id int) error {
+func (c *RollbarAPIClient) DeleteTeam(id int) error {
 	l := log.With().
 		Int("id", id).
 		Logger()
@@ -191,7 +191,7 @@ func (c *RollbarApiClient) DeleteTeam(id int) error {
 }
 
 // AssignUserToTeam assigns a user to a Rollbar team.
-func (c *RollbarApiClient) AssignUserToTeam(teamID, userID int) error {
+func (c *RollbarAPIClient) AssignUserToTeam(teamID, userID int) error {
 	l := log.With().Int("userID", userID).Int("teamID", teamID).Logger()
 	l.Debug().Msg("Assigning user to team")
 	resp, err := c.Resty.R().
@@ -221,7 +221,7 @@ func (c *RollbarApiClient) AssignUserToTeam(teamID, userID int) error {
 }
 
 // RemoveUserFromTeam removes a user from a Rollbar team.
-func (c *RollbarApiClient) RemoveUserFromTeam(userID, teamID int) error {
+func (c *RollbarAPIClient) RemoveUserFromTeam(userID, teamID int) error {
 	l := log.With().Int("userID", userID).Int("teamID", teamID).Logger()
 	l.Debug().Msg("Removing user from team")
 	resp, err := c.Resty.R().
@@ -253,7 +253,7 @@ func (c *RollbarApiClient) RemoveUserFromTeam(userID, teamID int) error {
 }
 
 // FindTeamID finds the ID for a team.
-func (c *RollbarApiClient) FindTeamID(name string) (int, error) {
+func (c *RollbarAPIClient) FindTeamID(name string) (int, error) {
 	l := log.With().
 		Str("team_name", name).
 		Logger()
@@ -275,7 +275,7 @@ func (c *RollbarApiClient) FindTeamID(name string) (int, error) {
 
 // ListTeamProjectIDs lists IDs of all Rollbar projects to which a given team is
 // assigned.
-func (c *RollbarApiClient) ListTeamProjectIDs(teamID int) ([]int, error) {
+func (c *RollbarAPIClient) ListTeamProjectIDs(teamID int) ([]int, error) {
 	l := log.With().Int("teamID", teamID).Logger()
 	l.Debug().Msg("Listing projects for team")
 	resp, err := c.Resty.R().
@@ -304,7 +304,7 @@ func (c *RollbarApiClient) ListTeamProjectIDs(teamID int) ([]int, error) {
 }
 
 // AssignTeamToProject assigns a Rollbar team to a project.
-func (c *RollbarApiClient) AssignTeamToProject(teamID, projectID int) error {
+func (c *RollbarAPIClient) AssignTeamToProject(teamID, projectID int) error {
 	l := log.With().
 		Int("teamID", teamID).
 		Int("projectID", projectID).
@@ -331,7 +331,7 @@ func (c *RollbarApiClient) AssignTeamToProject(teamID, projectID int) error {
 }
 
 // RemoveTeamFromProject removes a Rollbar team from a project.
-func (c *RollbarApiClient) RemoveTeamFromProject(teamID, projectID int) error {
+func (c *RollbarAPIClient) RemoveTeamFromProject(teamID, projectID int) error {
 	l := log.With().
 		Int("teamID", teamID).
 		Int("projectID", projectID).

--- a/client/user.go
+++ b/client/user.go
@@ -38,7 +38,7 @@ type User struct {
 }
 
 // ListUsers lists all Rollbar users.
-func (c *RollbarApiClient) ListUsers() (users []User, err error) {
+func (c *RollbarAPIClient) ListUsers() (users []User, err error) {
 	log.Debug().Msg("Listing users")
 	u := c.BaseURL + pathUsers
 	resp, err := c.Resty.R().
@@ -63,7 +63,7 @@ func (c *RollbarApiClient) ListUsers() (users []User, err error) {
 }
 
 // ReadUser reads a Rollbar user from the API.
-func (c *RollbarApiClient) ReadUser(id int) (user User, err error) {
+func (c *RollbarAPIClient) ReadUser(id int) (user User, err error) {
 	l := log.With().Int("id", id).Logger()
 	l.Debug().Msg("Reading user from API")
 	u := c.BaseURL + pathUser
@@ -90,7 +90,7 @@ func (c *RollbarApiClient) ReadUser(id int) (user User, err error) {
 
 // FindUserID finds the user ID for a given email.  WARNING: this is a
 // potentially slow call.  Don't repeat it unnecessarily.
-func (c *RollbarApiClient) FindUserID(email string) (int, error) {
+func (c *RollbarAPIClient) FindUserID(email string) (int, error) {
 	l := log.With().Str("email", email).Logger()
 	l.Debug().Msg("Getting user ID from email")
 	users, err := c.ListUsers()
@@ -109,7 +109,7 @@ func (c *RollbarApiClient) FindUserID(email string) (int, error) {
 }
 
 // ListUserTeams lists a Rollbar user's teams.
-func (c *RollbarApiClient) ListUserTeams(userID int) (teams []Team, err error) {
+func (c *RollbarAPIClient) ListUserTeams(userID int) (teams []Team, err error) {
 	l := log.With().Int("userID", userID).Logger()
 	l.Debug().Msg("Reading teams for Rollbar user")
 	u := c.BaseURL + pathUserTeams
@@ -136,7 +136,7 @@ func (c *RollbarApiClient) ListUserTeams(userID int) (teams []Team, err error) {
 
 // ListUserCustomTeams lists a Rollbar user's custom defined teams, excluding
 // system teams "Everyone" and "Owners".
-func (c *RollbarApiClient) ListUserCustomTeams(userID int) (teams []Team, err error) {
+func (c *RollbarAPIClient) ListUserCustomTeams(userID int) (teams []Team, err error) {
 	teams, err = c.ListUserTeams(userID)
 	teams = filterSystemTeams(teams)
 	return

--- a/rollbar/data_source_project.go
+++ b/rollbar/data_source_project.go
@@ -74,7 +74,7 @@ func dataSourceProject() *schema.Resource {
 func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 
-	c := meta.(*client.RollbarApiClient)
+	c := meta.(*client.RollbarAPIClient)
 	pl, err := c.ListProjects()
 	if err != nil {
 		return err

--- a/rollbar/data_source_project_access_token.go
+++ b/rollbar/data_source_project_access_token.go
@@ -115,7 +115,7 @@ func dataSourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceDat
 		Logger()
 	l.Debug().Msg("Reading project access token from Rollbar")
 
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	tokens, err := c.ListProjectAccessTokens(projectID)
 	if err != nil {
 		return diag.FromErr(err)

--- a/rollbar/data_source_project_access_tokens.go
+++ b/rollbar/data_source_project_access_tokens.go
@@ -133,7 +133,7 @@ func dataSourceProjectAccessTokensRead(ctx context.Context, d *schema.ResourceDa
 		Logger()
 	l.Debug().Msg("Reading project access token data from Rollbar")
 
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	tokens, err := c.ListProjectAccessTokens(projectID)
 	if err != nil {
 		return diag.FromErr(err)

--- a/rollbar/data_source_projects.go
+++ b/rollbar/data_source_projects.go
@@ -83,7 +83,7 @@ func dataSourceProjects() *schema.Resource {
 func dataSourceProjectsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	log.Debug().Msg("Reading project list from API")
 	var diags diag.Diagnostics
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 
 	projects, err := c.ListProjects()
 	if err != nil {

--- a/rollbar/data_source_projects_test.go
+++ b/rollbar/data_source_projects_test.go
@@ -70,7 +70,7 @@ func (s *AccSuite) configDataSourceProjects() string {
 func (s *AccSuite) checkProjectInProjectDataSource(rn string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
 		// How many projects should we expect in the project list?
-		c := s.provider.Meta().(*client.RollbarApiClient)
+		c := s.provider.Meta().(*client.RollbarAPIClient)
 		pl, err := c.ListProjects()
 		s.Nil(err)
 		expectedCount := strconv.Itoa(len(pl))

--- a/rollbar/provider_test.go
+++ b/rollbar/provider_test.go
@@ -165,8 +165,8 @@ func (s *AccSuite) getResourceAttrInt(ts *terraform.State, resourceName string, 
 }
 
 // client returns the current Rollbar API client
-func (s *AccSuite) client() *client.RollbarApiClient {
-	return s.provider.Meta().(*client.RollbarApiClient)
+func (s *AccSuite) client() *client.RollbarAPIClient {
+	return s.provider.Meta().(*client.RollbarAPIClient)
 }
 
 // getResourceAttrIntSlice returns value of a named attribute of a Terraform

--- a/rollbar/resource_project.go
+++ b/rollbar/resource_project.go
@@ -92,7 +92,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 	l := log.With().Str("name", name).Logger()
 	l.Info().Msg("Creating new Rollbar project resource")
 
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	p, err := c.CreateProject(name)
 	if err != nil {
 		l.Err(err).Send()
@@ -160,7 +160,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 		Logger()
 	l.Info().Msg("Reading Rollbar project resource")
 
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	proj, err := c.ReadProject(projectID)
 	if err == client.ErrNotFound {
 		l.Debug().Msg("Project not found on Rollbar - removing from state")
@@ -202,7 +202,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		Ints("team_ids", teamIDs).
 		Logger()
 	l.Debug().Msg("Updating rollbar_project resource")
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	err := c.UpdateProjectTeams(projectID, teamIDs)
 	if err != nil {
 		l.Err(err).Msg("Error updating rollbar_project resource")
@@ -219,7 +219,7 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interf
 		Int("projectID", projectID).
 		Logger()
 	l.Info().Msg("Deleting rollbar_project resource")
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	err := c.DeleteProject(projectID)
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_project resource")

--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -139,7 +139,7 @@ func resourceProjectAccessTokenCreate(ctx context.Context, d *schema.ResourceDat
 		Logger()
 	l.Debug().Msg("Creating new project access token")
 
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	pat, err := c.CreateProjectAccessToken(client.ProjectAccessTokenCreateArgs{
 		Name:                 name,
 		ProjectID:            projectID,
@@ -167,7 +167,7 @@ func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData,
 		Logger()
 	l.Debug().Msg("Reading resource project access token")
 
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	pat, err := c.ReadProjectAccessToken(projectID, accessToken)
 	if err == client.ErrNotFound {
 		d.SetId("")
@@ -200,7 +200,7 @@ func resourceProjectAccessTokenUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 	l := log.With().Interface("args", args).Logger()
 	l.Debug().Msg("Updating resource project access token")
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	err := c.UpdateProjectAccessToken(args)
 	if err != nil {
 		log.Err(err).Send()
@@ -220,7 +220,7 @@ func resourceProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceDat
 		Logger()
 	l.Debug().Msg("Deleting resource project access token")
 
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	err := c.DeleteProjectAccessToken(projectID, accessToken)
 	if err != nil {
 		return diag.FromErr(err)

--- a/rollbar/resource_project_access_token_test.go
+++ b/rollbar/resource_project_access_token_test.go
@@ -457,7 +457,7 @@ func (s *AccSuite) checkProjectAccessToken(resourceName string) resource.TestChe
 		if err != nil {
 			return err
 		}
-		c := s.provider.Meta().(*client.RollbarApiClient)
+		c := s.provider.Meta().(*client.RollbarAPIClient)
 		pat, err := c.ReadProjectAccessToken(projectID, accessToken)
 		if err != nil {
 			return err
@@ -508,7 +508,7 @@ func (s *AccSuite) checkProjectAccessTokenInTokenList(rn string) resource.TestCh
 		s.Nil(err)
 		projectID, err := s.getResourceAttrInt(ts, rn, "project_id")
 		s.Nil(err)
-		c := s.provider.Meta().(*client.RollbarApiClient)
+		c := s.provider.Meta().(*client.RollbarAPIClient)
 		pats, err := c.ListProjectAccessTokens(projectID)
 		s.Nil(err)
 		found := false
@@ -550,7 +550,7 @@ func (s *AccSuite) checkNoUnexpectedTokens(projectResourceName string, expectedT
 		if err != nil {
 			return err
 		}
-		c := s.provider.Meta().(*client.RollbarApiClient)
+		c := s.provider.Meta().(*client.RollbarAPIClient)
 		tokens, err := c.ListProjectAccessTokens(projectID)
 		s.Nil(err)
 		for _, t := range tokens {

--- a/rollbar/resource_project_test.go
+++ b/rollbar/resource_project_test.go
@@ -300,7 +300,7 @@ func (s *AccSuite) checkProjectExists(rn string, name string) resource.TestCheck
 	return func(ts *terraform.State) error {
 		id, err := s.getResourceIDInt(ts, rn)
 		s.Nil(err)
-		c := s.provider.Meta().(*client.RollbarApiClient)
+		c := s.provider.Meta().(*client.RollbarAPIClient)
 		proj, err := c.ReadProject(id)
 		s.Nil(err)
 		s.Equal(name, proj.Name, "project name from API does not match project name in Terraform config")
@@ -314,7 +314,7 @@ func (s *AccSuite) checkProjectInProjectList(rn string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
 		id, err := s.getResourceIDInt(ts, rn)
 		s.Nil(err)
-		c := s.provider.Meta().(*client.RollbarApiClient)
+		c := s.provider.Meta().(*client.RollbarAPIClient)
 		projList, err := c.ListProjects()
 		s.Nil(err)
 		found := false

--- a/rollbar/resource_team.go
+++ b/rollbar/resource_team.go
@@ -73,7 +73,7 @@ func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, m interface
 	level := d.Get("access_level").(string)
 	l := log.With().Str("name", name).Str("access_level", level).Logger()
 	l.Info().Msg("Creating rollbar_team resource")
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	t, err := c.CreateTeam(name, level)
 	if err != nil {
 		l.Err(err).Send()
@@ -92,7 +92,7 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		Int("id", id).
 		Logger()
 	l.Info().Msg("Reading rollbar_team resource")
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	t, err := c.ReadTeam(id)
 	if err == client.ErrNotFound {
 		d.SetId("")
@@ -115,7 +115,7 @@ func resourceTeamDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 	l := log.With().Int("id", id).Logger()
 	l.Info().Msg("Deleting rollbar_team resource")
-	c := m.(*client.RollbarApiClient)
+	c := m.(*client.RollbarAPIClient)
 	err := c.DeleteTeam(id)
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_team resource")

--- a/rollbar/resource_team_test.go
+++ b/rollbar/resource_team_test.go
@@ -245,7 +245,7 @@ func (s *AccSuite) checkTeam(rn, teamName, accessLevel string) resource.TestChec
 	return func(ts *terraform.State) error {
 		id, err := s.getResourceIDInt(ts, rn)
 		s.Nil(err)
-		c := s.provider.Meta().(*client.RollbarApiClient)
+		c := s.provider.Meta().(*client.RollbarAPIClient)
 		t, err := c.ReadTeam(id)
 		s.Nil(err)
 		s.Equal(teamName, t.Name, "team name from API does not match team name in Terraform config")

--- a/rollbar/resource_user.go
+++ b/rollbar/resource_user.go
@@ -95,7 +95,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 // inviting user to specified groups, and removing user from groups no longer
 // specified.
 func resourceUserCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*client.RollbarApiClient)
+	c := meta.(*client.RollbarAPIClient)
 	email := d.Get("email").(string)
 	teamIDs := getTeamIDs(d)
 	l := log.With().
@@ -164,7 +164,7 @@ func resourceUserCreateOrUpdate(ctx context.Context, d *schema.ResourceData, met
 // resourceUserAddRemoveTeamsArgs encapsulates the arguments to
 // resourceUserAddTeams and resourceUserRemoveTeams.
 type resourceUserAddRemoveTeamsArgs struct {
-	client        *client.RollbarApiClient
+	client        *client.RollbarAPIClient
 	userID        int
 	email         string
 	teamsExpected map[int]bool
@@ -274,7 +274,7 @@ func resourceUserRemoveTeams(args resourceUserAddRemoveTeamsArgs) error {
 }
 
 // resourceUserCurrentTeams returns user's current team memberships.
-func resourceUserCurrentTeams(c *client.RollbarApiClient, email string, userID int) (currentTeams map[int]bool, err error) {
+func resourceUserCurrentTeams(c *client.RollbarAPIClient, email string, userID int) (currentTeams map[int]bool, err error) {
 	l := log.With().
 		Str("email", email).
 		Int("user_id", userID).
@@ -319,7 +319,7 @@ func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{
 		Int("userID", userID).
 		Logger()
 	l.Info().Msg("Reading rollbar_user resource")
-	c := meta.(*client.RollbarApiClient)
+	c := meta.(*client.RollbarAPIClient)
 	var err error
 
 	// If user ID is not in state, try to query it from Rollbar
@@ -379,7 +379,7 @@ func resourceUserDelete(_ context.Context, d *schema.ResourceData, meta interfac
 		Str("email", email).
 		Logger()
 	l.Info().Msg("Deleting rollbar_user resource")
-	c := meta.(*client.RollbarApiClient)
+	c := meta.(*client.RollbarAPIClient)
 
 	// Try to get user ID
 	userID := d.Get("user_id").(int)
@@ -432,7 +432,7 @@ func resourceUserImporter(ctx context.Context, d *schema.ResourceData, meta inte
 	l.Info().Msg("Importing rollbar_user resource")
 
 	var teamIDs []int
-	c := meta.(*client.RollbarApiClient)
+	c := meta.(*client.RollbarAPIClient)
 
 	invitations, err := c.FindInvitations(email)
 	if err != nil && err != client.ErrNotFound {


### PR DESCRIPTION
This PR closes #162 by rename `RollbarApiClient` to `RollbarAPIClient`, in accordance with Go style guidelines.