### PR TITLE
Fix link in history

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ History
 -------
 
 Derived from
-[jmcvetta/terraform-provider-rollbar-jmcvetta](https://github.com/jmcvetta/terraform-provider-rollbar-jmcvetta)
-and
 [babbel/terraform-provider-rollbar](https://github.com/babbel/terraform-provider-rollbar)
+and
+[jmcvetta/terraform-provider-rollbar](https://github.com/jmcvetta/terraform-provider-rollbar)


### PR DESCRIPTION
This PR fixes the link to `jmcvetta/terraform-provider-rollbar` in the _History_ section of the README.