### PR TITLE
add NPM package ecosystem to dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds NPM to the package ecosystems monitored by Dependabot.