### PR TITLE
replace from_user_id: 5325 with from_user_id: null

### DIFF
--- a/client/fixtures/invitation/create.json
+++ b/client/fixtures/invitation/create.json
@@ -3,7 +3,7 @@
   "result": {
     "date_created": 1603191497,
     "date_redeemed": null,
-    "from_user_id": 5325,
+    "from_user_id": null,
     "id": 153648,
     "status": "pending",
     "team_id": 572097,

--- a/client/fixtures/invitation/list.json
+++ b/client/fixtures/invitation/list.json
@@ -13,7 +13,7 @@
     {
       "date_created": 1603192477,
       "date_redeemed": null,
-      "from_user_id": 5325,
+      "from_user_id": null,
       "id": 153650,
       "status": "pending",
       "team_id": 676971,

--- a/client/fixtures/invitation/list_662037.json
+++ b/client/fixtures/invitation/list_662037.json
@@ -3,7 +3,7 @@
   "result": [
     {
       "id": 153556,
-      "from_user_id": 5325,
+      "from_user_id": null,
       "team_id": 662037,
       "to_email": "jason.mcvetta+test0@gmail.com",
       "status": "canceled",
@@ -12,7 +12,7 @@
     },
     {
       "id": 153644,
-      "from_user_id": 5325,
+      "from_user_id": null,
       "team_id": 662037,
       "to_email": "jason.mcvetta+test0@gmail.com",
       "status": "canceled",
@@ -21,7 +21,7 @@
     },
     {
       "id": 153646,
-      "from_user_id": 5325,
+      "from_user_id": null,
       "team_id": 662037,
       "to_email": "jason.mcvetta+test0@gmail.com",
       "status": "canceled",
@@ -30,7 +30,7 @@
     },
     {
       "id": 153648,
-      "from_user_id": 5325,
+      "from_user_id": null,
       "team_id": 662037,
       "to_email": "jason.mcvetta+test0@gmail.com",
       "status": "pending",

--- a/client/fixtures/invitation/list_676971.json
+++ b/client/fixtures/invitation/list_676971.json
@@ -12,7 +12,7 @@
     },
     {
       "id": 153650,
-      "from_user_id": 5325,
+      "from_user_id": null,
       "team_id": 676971,
       "to_email": "jason.mcvetta+test4@gmail.com",
       "status": "canceled",

--- a/client/fixtures/invitation/read.json
+++ b/client/fixtures/invitation/read.json
@@ -3,7 +3,7 @@
     "result": {
         "date_created": 1603192477,
         "date_redeemed": null,
-        "from_user_id": 5325,
+        "from_user_id": null,
         "id": 153650,
         "status": "pending",
         "team_id": 676971,

--- a/client/invitation_test.go
+++ b/client/invitation_test.go
@@ -53,7 +53,7 @@ func (s *Suite) TestListInvitations() {
 		{
 			DateCreated:  1603192477,
 			DateRedeemed: 0,
-			FromUserID:   5325,
+			FromUserID:   0,
 			ID:           153650,
 			Status:       "pending",
 			TeamID:       676971,
@@ -82,7 +82,7 @@ func (s *Suite) TestListPendingInvitations() {
 	expected := []Invitation{
 		{
 			ID:           153648,
-			FromUserID:   5325,
+			FromUserID:   0,
 			TeamID:       662037,
 			ToEmail:      "jason.mcvetta+test0@gmail.com",
 			Status:       "pending",
@@ -144,7 +144,7 @@ func (s *Suite) TestReadInvitation() {
 	expected := Invitation{
 		DateCreated:  1603192477,
 		DateRedeemed: 0,
-		FromUserID:   5325,
+		FromUserID:   0,
 		ID:           153650,
 		Status:       "pending",
 		TeamID:       676971,

--- a/rollbar/vcr/invited_user.yaml
+++ b/rollbar/vcr/invited_user.yaml
@@ -180,7 +180,7 @@ interactions:
         "result": [
           {
             "id": 158403,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704998,
             "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
             "status": "pending",
@@ -210,7 +210,7 @@ interactions:
         "result": [
           {
             "id": 158376,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704936,
             "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
             "status": "pending",
@@ -261,7 +261,7 @@ interactions:
         "err": 0,
         "result": {
           "id": 158417,
-          "from_user_id": 5325,
+          "from_user_id": null,
           "team_id": 705099,
           "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
           "status": "pending",
@@ -341,7 +341,7 @@ interactions:
         "result": [
           {
             "id": 158403,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704998,
             "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
             "status": "pending",
@@ -371,7 +371,7 @@ interactions:
         "result": [
           {
             "id": 158376,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704936,
             "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
             "status": "pending",
@@ -401,7 +401,7 @@ interactions:
         "result": [
           {
             "id": 158417,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 705099,
             "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
             "status": "pending",
@@ -545,7 +545,7 @@ interactions:
         "result": [
           {
             "id": 158403,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704998,
             "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
             "status": "pending",
@@ -575,7 +575,7 @@ interactions:
         "result": [
           {
             "id": 158376,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704936,
             "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
             "status": "pending",
@@ -605,7 +605,7 @@ interactions:
         "result": [
           {
             "id": 158417,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 705099,
             "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
             "status": "pending",
@@ -774,7 +774,7 @@ interactions:
         "result": [
           {
             "id": 158403,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704998,
             "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
             "status": "pending",
@@ -804,7 +804,7 @@ interactions:
         "result": [
           {
             "id": 158376,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704936,
             "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
             "status": "pending",
@@ -834,7 +834,7 @@ interactions:
         "result": [
           {
             "id": 158417,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 705099,
             "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
             "status": "pending",

--- a/rollbar/vcr/registered_user.yaml
+++ b/rollbar/vcr/registered_user.yaml
@@ -193,7 +193,7 @@ interactions:
         "result": [
           {
             "id": 158403,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704998,
             "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
             "status": "pending",
@@ -223,7 +223,7 @@ interactions:
         "result": [
           {
             "id": 158376,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704936,
             "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
             "status": "pending",
@@ -253,7 +253,7 @@ interactions:
         "result": [
           {
             "id": 158417,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 705099,
             "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
             "status": "accepted",
@@ -462,7 +462,7 @@ interactions:
         "result": [
           {
             "id": 158403,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704998,
             "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
             "status": "pending",
@@ -492,7 +492,7 @@ interactions:
         "result": [
           {
             "id": 158376,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704936,
             "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
             "status": "pending",
@@ -522,7 +522,7 @@ interactions:
         "result": [
           {
             "id": 158417,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 705099,
             "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
             "status": "accepted",
@@ -706,7 +706,7 @@ interactions:
         "result": [
           {
             "id": 158403,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704998,
             "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
             "status": "pending",
@@ -736,7 +736,7 @@ interactions:
         "result": [
           {
             "id": 158376,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704936,
             "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
             "status": "pending",
@@ -766,7 +766,7 @@ interactions:
         "result": [
           {
             "id": 158417,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 705099,
             "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
             "status": "accepted",
@@ -901,7 +901,7 @@ interactions:
         "result": [
           {
             "id": 158403,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704998,
             "to_email": "jason.mcvetta+tf-acc-test-a4mi14cqy9@gmail.com",
             "status": "pending",
@@ -931,7 +931,7 @@ interactions:
         "result": [
           {
             "id": 158376,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 704936,
             "to_email": "jason.mcvetta+tf-acc-test-eiw2mohch5@gmail.com",
             "status": "pending",
@@ -961,7 +961,7 @@ interactions:
         "result": [
           {
             "id": 158417,
-            "from_user_id": 5325,
+            "from_user_id": null,
             "team_id": 705099,
             "to_email": "jason.mcvetta+tf-acc-test-7lppmg40pk@gmail.com",
             "status": "accepted",


### PR DESCRIPTION
This PR accommodates test fixtures and expected results to the API changes made pursuant to #63, by replacing `from_user_id` value `5325` with the null value.