### PR TITLE
Tweak Github cache for Go

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -21,10 +21,14 @@ jobs:
       # Restore cache
       - uses: actions/cache@v2
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          # In test.yml we do matrixed version testing.  Included in the version
+          # matrix is the blank string, indicating to test against the latest
+          # version of Go.  Since we are using the latest version of Go here
+          # too, we will use the cache key for Go with a blank version number.
+          key: ${{ runner.os }}-go-v-${{ hashFiles('**/go.sum') }}
 
       # Wait for up to ten minutes for previous run to complete; abort if not
       # done by then.

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -24,10 +24,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          # In test.yml we do matrixed version testing.  Included in the version
-          # matrix is the blank string, indicating to test against the latest
-          # version of Go.  Since we are using the latest version of Go here
-          # too, we will use the cache key for Go with a blank version number.
+          # Blank version number means latest version of Go.
           key: ${{ runner.os }}-go-v-${{ hashFiles('**/go.sum') }}
 
       # Wait for up to ten minutes for previous run to complete; abort if not

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -75,6 +75,15 @@ jobs:
     #    Example: mvn compile, or npm install or pip install goes here
     # 3. Invoke Scan with the github token. Leave the workspace empty to use relative url
 
+    # Restore cache
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        # Blank version number means latest version of Go.
+        key: ${{ runner.os }}-go-v-${{ hashFiles('**/go.sum') }}
+
     - name: Perform Scan
       uses: ShiftLeftSecurity/scan-action@master
       env:

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -75,15 +75,6 @@ jobs:
     #    Example: mvn compile, or npm install or pip install goes here
     # 3. Invoke Scan with the github token. Leave the workspace empty to use relative url
 
-    # Restore cache
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        # Blank version number means latest version of Go.
-        key: ${{ runner.os }}-go-v-${{ hashFiles('**/go.sum') }}
-
     - name: Perform Scan
       uses: ShiftLeftSecurity/scan-action@master
       env:

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -25,7 +25,16 @@ jobs:
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
 
-    # Initializes the CodeQL tools for scanning.
+    # Restore cache
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        # Blank version number means latest version of Go.
+        key: ${{ runner.os }}-go-v-${{ hashFiles('**/go.sum') }}
+
+      # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          # In test.yml we do matrixed version testing.  Included in the version
-          # matrix is the blank string, indicating to test against the latest
-          # version of Go.  Since we are using the latest version of Go here
-          # too, we will use the cache key for Go with a blank version number.
+          # Blank version number means latest version of Go.
           key: ${{ runner.os }}-go-v-${{ hashFiles('**/go.sum') }}
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,11 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+          # In test.yml we do matrixed version testing.  Included in the version
+          # matrix is the blank string, indicating to test against the latest
+          # version of Go.  Since we are using the latest version of Go here
+          # too, we will use the cache key for Go with a blank version number.
+          key: ${{ runner.os }}-go-v-${{ hashFiles('**/go.sum') }}
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,10 +76,12 @@ jobs:
       # Restore cache
       - uses: actions/cache@v2
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          # Blank version number means latest version of Go.
+          key: ${{ runner.os }}-go-v-${{ hashFiles('**/go.sum') }}
+
 
       # Install Provider
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,9 @@ jobs:
       # Restore cache
       - uses: actions/cache@v2
         with:
-          path: ~/go/pkg/mod
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
           key: ${{ runner.os }}-go-v${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
 
       # Run unit tests


### PR DESCRIPTION
This PR tweaks cache configuration in our Github Actions workflows.  Jobs share rather than duplicate cache.  Add `~/.cache/go-build` to the set of cached folders. Add caching to `CodeQL` job.
