### PR TITLE
doc: may take up to 10 minutes to build release binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ unsentimental](http://sentimentalversioning.org/).
 >
 > _-- from the semantic-release docs_
 
+After a new release has been created by semantic-release, it may take up to 10
+minutes for the provider binaries to be built and attached by GoReleaser.
+
 
 ### Terraform Versions
 


### PR DESCRIPTION
This PR updates the README to document that building provider binaries may take up to 10 minutes after semantic-release creates a new release.