### PR TITLE
Build before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Semantic Release
 on:
   push:
-    branches:
-      - master
+#    branches:
+#      - master
 jobs:
   release:
     name: Semantic Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Semantic Release
 on:
   push:
-#    branches:
-#      - master
+    branches:
+      - master
 jobs:
   release:
     name: Semantic Release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,8 +6,8 @@
     "@semantic-release/git",
     ["@semantic-release/exec",
       {
-        "prepareCmd": "goreleaser build --rm-dist --snapshot",
-        "publishCmd": "goreleaser release --rm-dist"
+        "prepareCmd": "date; goreleaser build --rm-dist --snapshot; rm -rv dist; date",
+        "publishCmd": "date; goreleaser release --rm-dist; date"
       }
     ]
   ],

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
     "@semantic-release/git",
     ["@semantic-release/exec",
       {
-        "prepareCmd": "goreleaser build --rm-dist",
+        "prepareCmd": "goreleaser build --rm-dist --snapshot",
         "publishCmd": "goreleaser release --rm-dist"
       }
     ]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,8 +6,8 @@
     "@semantic-release/git",
     ["@semantic-release/exec",
       {
-        "prepareCmd": "date; goreleaser build --rm-dist --snapshot; rm -rv dist; date",
-        "publishCmd": "date; goreleaser release --rm-dist; date"
+        "prepareCmd": "goreleaser build --rm-dist --snapshot; rm -rv dist",
+        "publishCmd": "goreleaser release --rm-dist"
       }
     ]
   ],

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
     "@semantic-release/git",
     ["@semantic-release/exec",
       {
-        "publishCmd": "goreleaser release --rm-dist"
+        "publishCmd": "goreleaser build --rm-dist && goreleaser release --rm-dist"
       }
     ]
   ],

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,5 +10,9 @@
       }
     ]
   ],
-  "preset": "conventionalcommits"
+  "preset": "conventionalcommits",
+  "branches": [
+      "master",
+      "build-before-release"
+  ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
     "@semantic-release/git",
     ["@semantic-release/exec",
       {
-        "publishCmd": "goreleaser build --rm-dist && goreleaser release --rm-dist"
+        "publishCmd": "goreleaser build --rm-dist && rm -rvf dist && goreleaser release --rm-dist"
       }
     ]
   ],

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,6 @@
   ],
   "preset": "conventionalcommits",
   "branches": [
-      "master",
-      "build-before-release"
+      "master"
   ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,8 @@
     "@semantic-release/git",
     ["@semantic-release/exec",
       {
-        "publishCmd": "goreleaser build --rm-dist && rm -rvf dist && goreleaser release --rm-dist"
+        "prepareCmd": "goreleaser build --rm-dist",
+        "publishCmd": "goreleaser release --rm-dist"
       }
     ]
   ],


### PR DESCRIPTION
This PR ensures the time is minimized between a Github release is created and the time build artifacts are uploaded, by priming the Go build cache in the `prepare` step.  