### PR TITLE
Do not build release artifacts for OpenBSD

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,6 @@ builds:
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
-    - openbsd
     - linux
     - freebsd
     - darwin


### PR DESCRIPTION
This PR updates GoReleaser configuration, removing OpenBSD from the list of platforms for which releases artifacts are built.  OpenBSD is not included in the [reference GoReleaser configuration file](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.goreleaser.yml) from Hashicorp.  This change will somewhat decrease the time required to publish a new release.  