### PR TITLE
ci: run acceptance tests on cron schedule

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,5 +1,8 @@
 name: Acceptance Tests
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '0 10 * * 3'
 
 jobs:
 


### PR DESCRIPTION
This PR updates Github Actions workflow configuration, to run our Acceptance Tests on a periodic schedule, as well as on each push.