### PR TITLE
Test install provider from registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Semantic Release
 on:
   push:
     branches:
+      - master
 jobs:
   release:
     name: Semantic Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         run: npx semantic-release
+
+      - name: Sleep for 30 seconds
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '30s'
+
+      - name: Confirm install from Registry
+        working-directory: ./example
+        run: terraform init

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Semantic Release
 on:
   push:
     branches:
-      - master
 jobs:
   release:
     name: Semantic Release


### PR DESCRIPTION
This PR adds a post-publish test checking that the latest version of the provider can be installed from the Terraform Registry.  Closes #206.