### PR TITLE
chore: gitignore Terraform lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 terraform.tfstate*
 *.tfvars
 .terraform/
+.terraform.lock.hcl
 
 # ShiftLeft Scan reports
 reports/


### PR DESCRIPTION
This PR adds Terraform's new `.terraform.lock.hcl` file to `.gitignore`.