### PR TITLE
test: debug output when running `make testacc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test:
 	@#echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
 
 testacc: 
-	TF_ACC=1 go test -covermode=atomic -coverprofile=coverage.out $(TEST) -v $(TESTARGS) -timeout 120m   
+	TF_ACC=1 TERRAFORM_PROVIDER_ROLLBAR_DEBUG=1 go test -covermode=atomic -coverprofile=coverage.out $(TEST) -v $(TESTARGS) -timeout 120m   
 
 slscan:
 	./.slscan.sh


### PR DESCRIPTION
This PR updates `Makefile` to enable provider debug output when running `make testacc`.