### PR TITLE
ci: Setup terraform before test install provider

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         run: npx semantic-release
 
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_wrapper: false
+          terraform_version: "${{ matrix.terraform }}"
+
       - name: Sleep for 30 seconds
         uses: jakejarvis/wait-action@master
         with:

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test:
 	@#echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
 
 testacc: 
-	TF_ACC=1 go test -covermode=atomic -coverprofile=coverage.out $(TEST) -v $(TESTARGS) -timeout 120m   
+	TF_ACC=1 TERRAFORM_PROVIDER_ROLLBAR_DEBUG=1 go test -covermode=atomic -coverprofile=coverage.out $(TEST) -v $(TESTARGS) -timeout 120m   
 
 slscan:
 	./.slscan.sh


### PR DESCRIPTION
This PR installs Terraform in the `release.yml` workflow before running it to check successful publication of the release.

Why did this work before??  Terraform was not installed by the workflow, but I was still able to run it.  Is Terraform installed by default in Github runners?  Or is it because `test.yml` installs it, and the runners aren't fully isolated from one another?
