### PR TITLE
bump `go.mod` to Go v1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rollbar/terraform-provider-rollbar
 
-go 1.14
+go 1.15
 
 // Until https://github.com/rs/zerolog/pull/266 or https://github.com/rs/zerolog/pull/267
 // is included in the next release


### PR DESCRIPTION
This PR bumps the Go version specified in `go.mod` to v1.15.