### PR TITLE
Add team data source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,19 @@ install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
+uninstall:
+	rm -fr ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}/${BINARY}
+
 install012: build
 	mkdir -p ~/.terraform.d/plugins/${OS_ARCH}/
 	mv ${BINARY} ~/.terraform.d/plugins/${OS_ARCH}/terraform-provider-${NAME}_v${VERSION}
 
-test: 
+test:
 	go test -covermode=atomic -coverprofile=coverage.out $(TEST) || exit 1
-	@#echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
+	@#echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
-testacc: 
-	TF_ACC=1 TERRAFORM_PROVIDER_ROLLBAR_DEBUG=1 go test -covermode=atomic -coverprofile=coverage.out $(TEST) -v $(TESTARGS) -timeout 120m   
+testacc:
+	TF_ACC=1 TERRAFORM_PROVIDER_ROLLBAR_DEBUG=1 go test -covermode=atomic -coverprofile=coverage.out $(TEST) -v $(TESTARGS) -timeout 120m
 
 slscan:
 	./.slscan.sh

--- a/rollbar/data_source_team.go
+++ b/rollbar/data_source_team.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Rollbar, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package rollbar
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/rollbar/terraform-provider-rollbar/client"
+	"github.com/rs/zerolog/log"
+)
+
+// dataSourceTeam is a data source returning a Rollbar team.
+func dataSourceTeam() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTeamRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Description: "Human readable name for the team",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+
+			// Computed values
+			"id": {
+				Description: "ID of the team",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"access_level": {
+				Description: `The team's access level.  Must be "standard", "light", or "view".  Defaults to "standard".`,
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"account_id": {
+				Description: "ID of account that owns the team",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceTeamRead(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
+	name := data.Get("name").(string)
+
+	log.Debug().Msg("Reading team list from API")
+	c := m.(*client.RollbarAPIClient)
+	teams, err := c.ListTeams()
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var team client.Team
+	var found bool
+	for _, p := range teams {
+		if p.Name == name {
+			found = true
+			team = p
+		}
+	}
+
+	if !found {
+		data.SetId("")
+		return diag.FromErr(fmt.Errorf("no team with the name %s found", name))
+	}
+
+	id := fmt.Sprintf("%d", team.ID)
+	data.SetId(id)
+	mustSet(data, "name", team.Name)
+	mustSet(data, "account_id", team.AccountID)
+	mustSet(data, "access_level", team.AccessLevel)
+	log.Debug().Msg("Successfully read rollbar_team resource")
+
+	return nil
+}

--- a/rollbar/data_source_team_test.go
+++ b/rollbar/data_source_team_test.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 Rollbar, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package rollbar
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/rs/zerolog/log"
+)
+
+// TestTeamDataSource tests reading a team with
+// `rollbar_team` data source.
+func (s *AccSuite) TestTeamDataSource() {
+	rn := "data.rollbar_team.test"
+
+	resource.ParallelTest(s.T(), resource.TestCase{
+		PreCheck:     func() { s.preCheck() },
+		Providers:    s.providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					log.Debug().Msg("Testing data source rollbar_team with invalid team name")
+				},
+				Config:      s.configDataSourceTeamNotFound(),
+				ExpectError: regexp.MustCompile("no team with the name"),
+			},
+			{
+				PreConfig: func() {
+					log.Debug().Msg("Testing data source rollbar_team")
+				},
+				Config: s.configDataSourceTeam(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rn, "name", s.randName),
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttrSet(rn, "account_id"),
+					resource.TestCheckResourceAttrSet(rn, "access_level"),
+				),
+			},
+		},
+	})
+}
+
+func (s *AccSuite) configDataSourceTeam() string {
+	// language=hcl
+	tmpl := `
+		resource "rollbar_team" "test" {
+		  name         = "%s"
+		}
+
+		data "rollbar_team" "test" {
+			name = "%s"
+			depends_on = [rollbar_team.test]
+		}
+	`
+	return fmt.Sprintf(tmpl, s.randName, s.randName)
+}
+
+func (s *AccSuite) configDataSourceTeamNotFound() string {
+	// language=hcl
+	tmpl := `
+		data "rollbar_team" "test" {
+			name = "%s"
+		}
+	`
+	return fmt.Sprintf(tmpl, s.randName)
+}

--- a/rollbar/provider.go
+++ b/rollbar/provider.go
@@ -63,6 +63,7 @@ func Provider() *schema.Provider {
 			"rollbar_projects":              dataSourceProjects(),
 			"rollbar_project_access_token":  dataSourceProjectAccessToken(),
 			"rollbar_project_access_tokens": dataSourceProjectAccessTokens(),
+			"rollbar_team":                  dataSourceTeam(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}


### PR DESCRIPTION
Added a team data source so it is possible to fetch a team's info without the possible side effects of a resource.

Also added `make uninstall`.