### PR TITLE
Fix: Teams for users with Owner access

### DIFF
--- a/rollbar/resource_user.go
+++ b/rollbar/resource_user.go
@@ -24,6 +24,7 @@ package rollbar
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rollbar/terraform-provider-rollbar/client"
@@ -284,7 +285,7 @@ func resourceUserCurrentTeams(c *client.RollbarAPIClient, email string, userID i
 	// Registered user team memberships
 	if userID != 0 {
 		var teams []client.Team
-		teams, err = c.ListUserCustomTeams(userID)
+		teams, err = c.ListUserTeams(userID)
 		if err != nil && err != client.ErrNotFound {
 			l.Err(err).Send()
 			return


### PR DESCRIPTION
**Terraform version**

Terraform v0.14.4
* provider registry.terraform.io/rollbar/rollbar v1.0.6

**Affected resource(s)**

* rollbar_user

**Terraform configuration files**

```
resource "rollbar_user" "test" {
  name     = "test"
  email      = "test@example.com"
  team_ids = [rollbar_team.Owners.id, rollbar_team.Everyone.id]
}
```

**Steps to reproduce**

1. `terraform apply`
3. `terraform plan`

**Expected outcome**

```
rollbar_user.test: Refreshing state... [id=12345]

No changes. Infrastructure is up-to-date.
```

**Actual output**

```
Terraform will perform the following actions:
  # rollbar_user.test will be updated in-place
  ~ resource "rollbar_user" "test" {
        id       = "test@example.com"
      ~ team_ids = [
          + 15002,
          + 159042,
        ]
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

**More context**

We have to have ability to manage users with Owners permission in Rollbar.
If we try to add user with this permission in Terraform config, terraform will try to update this user forever.

The issue in function `resource_user.resourceUserCurrentTeams`, it filter system teams when gets list of teams for user.