### PR TITLE
Fix ability to modify owners

### DIFF
--- a/client/team.go
+++ b/client/team.go
@@ -373,12 +373,12 @@ func (c *RollbarAPIClient) RemoveTeamFromProject(teamID, projectID int) error {
  * Convenience functions
  */
 
-// filterSystemTeams filters out the system team "Everyone" from a
+// filterSystemTeams filters out the system teams "Everyone" and "Owners" from a
 // list of Rollbar teams.
 func filterSystemTeams(teams []Team) []Team {
 	var customTeams []Team
 	for _, t := range teams {
-		if t.Name == "Everyone" {
+		if t.Name == "Everyone" || t.Name == "Owners" {
 			continue
 		}
 		customTeams = append(customTeams, t)

--- a/client/team.go
+++ b/client/team.go
@@ -373,12 +373,12 @@ func (c *RollbarAPIClient) RemoveTeamFromProject(teamID, projectID int) error {
  * Convenience functions
  */
 
-// filterSystemTeams filters out the system teams "Everyone" and "Owners" from a
+// filterSystemTeams filters out the system team "Everyone" from a
 // list of Rollbar teams.
 func filterSystemTeams(teams []Team) []Team {
 	var customTeams []Team
 	for _, t := range teams {
-		if t.Name == "Everyone" || t.Name == "Owners" {
+		if t.Name == "Everyone" {
 			continue
 		}
 		customTeams = append(customTeams, t)

--- a/client/user.go
+++ b/client/user.go
@@ -23,8 +23,9 @@
 package client
 
 import (
-	"github.com/rs/zerolog/log"
 	"strconv"
+
+	"github.com/rs/zerolog/log"
 )
 
 // User represents a Rollbar user.
@@ -135,11 +136,18 @@ func (c *RollbarAPIClient) ListUserTeams(userID int) (teams []Team, err error) {
 }
 
 // ListUserCustomTeams lists a Rollbar user's custom defined teams, excluding
-// system teams "Everyone" and "Owners".
+// system team "Everyone".
 func (c *RollbarAPIClient) ListUserCustomTeams(userID int) (teams []Team, err error) {
+	var customTeams []Team
 	teams, err = c.ListUserTeams(userID)
-	teams = filterSystemTeams(teams)
-	return
+
+	for _, t := range teams {
+		if t.Name == "Everyone" {
+			continue
+		}
+		customTeams = append(customTeams, t)
+	}
+	return customTeams, err
 }
 
 /*


### PR DESCRIPTION
**Terraform code**
```
# Imported team
resource "rollbar_team" "Owners" {
  name = "Owners"

  lifecycle {
    # `team` has `access_level = "owner"` but Rollbar provider
    # doesn't support this `access_level`
    ignore_changes = [
      access_level,
    ]
  }
}

# New user
resource "rollbar_user" "test" {
  email = "test@example.com"
  team_ids = [rollbar_team.Owners.id]
}
```

We have to have ability to manage Owners in Rollbar.
If we try to apply the code above - user will be added to Owners. But after that every run terraform will try to add user in Owners again because `Owners` filtered.


Based on https://github.com/rollbar/terraform-provider-rollbar/pull/231