### PR TITLE
fixing notification import

### DIFF
--- a/client/notification_test.go
+++ b/client/notification_test.go
@@ -112,19 +112,21 @@ func (s *Suite) TestReadNotification() {
 	// Success
 	r := responderFromFixture("notification/read.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
-	err := s.client.ReadNotification(id, channel)
+	n, err := s.client.ReadNotification(id, channel)
 	s.Nil(err)
+	s.Equal("new_item", n.Trigger)
 
 	s.checkServerErrors("GET", u, func() error {
-		err := s.client.ReadNotification(id, channel)
+		_, err := s.client.ReadNotification(id, channel)
 		return err
 	})
 
 	// Try to read a deleted notification
 	r = responderFromFixture("project/read_deleted.json", http.StatusOK)
 	httpmock.RegisterResponder("GET", u, r)
-	err = s.client.ReadNotification(id, channel)
+	n, err = s.client.ReadNotification(id, channel)
 	s.Equal(ErrNotFound, err)
+	s.Nil(n)
 }
 
 // TestDeleteNotification tests deleting a Rollbar notification.

--- a/rollbar/resource_notification.go
+++ b/rollbar/resource_notification.go
@@ -98,11 +98,13 @@ func resourceNotification() *schema.Resource {
 										Description: "Period",
 										Type:        schema.TypeFloat,
 										Optional:    true,
+										Default:     0,
 									},
 									"count": {
 										Description: "Count",
 										Type:        schema.TypeFloat,
 										Optional:    true,
+										Default:     0,
 									},
 								},
 							},
@@ -141,6 +143,7 @@ func resourceNotification() *schema.Resource {
 							Description: "Show message buttons (slack)",
 							Type:        schema.TypeBool,
 							Optional:    true,
+							Default:     false,
 						},
 						"service_key": {
 							Description: "Service key (pagerduty)",

--- a/rollbar/resource_notification.go
+++ b/rollbar/resource_notification.go
@@ -29,8 +29,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rollbar/terraform-provider-rollbar/client"
 	"github.com/rs/zerolog/log"
-	"os"
 	"strconv"
+	"strings"
 )
 
 var configMap = map[string][]string{"email": {"users", "teams"},
@@ -38,8 +38,11 @@ var configMap = map[string][]string{"email": {"users", "teams"},
 	"pagerduty": {"service_key"}}
 
 func CustomNotificationImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	channel := os.Getenv("NOTIFICATION_CHANNEL")
-	mustSet(d, "channel", channel)
+	splitID := strings.Split(d.Id(), ",")
+	if len(splitID) > 1 {
+		mustSet(d, "channel", splitID[0])
+		d.SetId(splitID[1])
+	}
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/rollbar/resource_notification.go
+++ b/rollbar/resource_notification.go
@@ -29,12 +29,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rollbar/terraform-provider-rollbar/client"
 	"github.com/rs/zerolog/log"
+	"os"
 	"strconv"
 )
 
 var configMap = map[string][]string{"email": {"users", "teams"},
 	"slack":     {"message_template", "channel", "show_message_buttons"},
 	"pagerduty": {"service_key"}}
+
+func CustomNotificationImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	channel := os.Getenv("NOTIFICATION_CHANNEL")
+	d.Set("channel", channel)
+	return []*schema.ResourceData{d}, nil
+}
 
 // resourceNotification constructs a resource representing a Rollbar notification.
 func resourceNotification() *schema.Resource {
@@ -45,7 +52,7 @@ func resourceNotification() *schema.Resource {
 		DeleteContext: resourceNotificationDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: CustomNotificationImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -89,12 +96,12 @@ func resourceNotification() *schema.Resource {
 									},
 									"period": {
 										Description: "Period",
-										Type:        schema.TypeInt,
+										Type:        schema.TypeFloat,
 										Optional:    true,
 									},
 									"count": {
 										Description: "Count",
-										Type:        schema.TypeInt,
+										Type:        schema.TypeFloat,
 										Optional:    true,
 									},
 								},
@@ -254,6 +261,30 @@ func resourceNotificationUpdate(ctx context.Context, d *schema.ResourceData, m i
 	return nil
 }
 
+func flattenConfig(config map[string]interface{}) *schema.Set {
+	var out = make([]interface{}, 0)
+	m := make(map[string]interface{})
+	for key, value := range config {
+		m[key] = value
+		out = append(out, m)
+	}
+	specResource := resourceNotification().Schema["config"].Elem.(*schema.Resource)
+	f := schema.HashResource(specResource)
+	return schema.NewSet(f, out)
+}
+
+func flattenRule(filters []interface{}, trigger string) *schema.Set {
+	var out = make([]interface{}, 0)
+	m := make(map[string]interface{})
+	m["filters"] = filters
+	out = append(out, m)
+	m["trigger"] = trigger
+	out = append(out, m)
+	specResource := resourceNotification().Schema["rule"].Elem.(*schema.Resource)
+	f := schema.HashResource(specResource)
+	return schema.NewSet(f, out)
+}
+
 func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	id := mustGetID(d)
 	channel := d.Get("channel").(string)
@@ -262,7 +293,7 @@ func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, m int
 		Logger()
 	l.Info().Msg("Reading rollbar_notification resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
-	err := c.ReadNotification(id, channel)
+	n, err := c.ReadNotification(id, channel)
 	if err == client.ErrNotFound {
 		d.SetId("")
 		l.Info().Msg("Notification not found - removed from state")
@@ -272,6 +303,9 @@ func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, m int
 		l.Err(err).Msg("error reading rollbar_notification resource")
 		return diag.FromErr(err)
 	}
+
+	mustSet(d, "config", flattenConfig(n.Config))
+	mustSet(d, "rule", flattenRule(n.Filters, n.Trigger))
 	l.Debug().Msg("Successfully read rollbar_notification resource")
 	return nil
 }

--- a/rollbar/resource_notification.go
+++ b/rollbar/resource_notification.go
@@ -39,7 +39,7 @@ var configMap = map[string][]string{"email": {"users", "teams"},
 
 func CustomNotificationImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	channel := os.Getenv("NOTIFICATION_CHANNEL")
-	d.Set("channel", channel)
+	mustSet(d, "channel", channel)
 	return []*schema.ResourceData{d}, nil
 }
 


### PR DESCRIPTION
## Description of the change
Fixing notification import, adding a channel name as a prefix for the ID
to import:
```
terraform import rollbar_notification.<resource_name>  <channel_name>,<id>
```
for example:
```
terraform import rollbar_notification.new_pagerduty pagerduty,5170362
```
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> ClubHouse stories and GitHub issues (delete irrelevant)

- Fix [ch]
- Fix #1

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
