### PR TITLE
feat: release v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform-provider-rollbar",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "description": "Terraform provider for Rollbar.com",
   "directories": {
     "doc": "docs",


### PR DESCRIPTION
This PR will trigger semantic-release to create a v1.4.0 release of terraform-provider-rollbar.

At this point the code is stable and ready for dogfooding at Rollbar.

All future release versions will be determined by semantic-release.