### PR TITLE
Add a link to docs with framework IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,11 @@ resource "rollbar_notification" "baz" {
 
 **Note about framework filtering**
 
-When using the framework filter in notification rules, the correct value is a number (passed in as a string). The list of framework values is shown below (last updated 9/15/2021):
+When using the framework filter in notification rules, the correct value is a number (passed in as a string).
+The current list of framework values is available at <https://docs.rollbar.com/docs/rql#framework-ids>.
+
+A copy of the list is shown below (last updated 9/15/2021):
+
 ```
 {
     'unknown': 0,


### PR DESCRIPTION
## Description of the change

Add https://docs.rollbar.com/docs/rql#framework-ids to `README.md`, so that the documentation refers to the current frameworks list.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> ClubHouse stories and GitHub issues (delete irrelevant)

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
