### PR TITLE
Add timeout for the golangci-lint GitHub action

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.33
+          args: --timeout=5m
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
## Description of the change

GitHub Action `golangci-lint` likes to timeout too quickly, so the CI jobs must be re-run. This PR addresses the issue by increasing the timeout to 5 minutes for the GH Action.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> ClubHouse stories and GitHub issues (delete irrelevant)

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
