### PR TITLE
Add `rollbar_team` Data Source to lookup existing teams.

### DIFF
--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -1,0 +1,40 @@
+`rollbar_team` Data Source
+==============================
+
+Use this data source to retrieve information about a Rollbar team.
+
+
+Example Usage
+-------------
+
+To retrieve info about a team by name or ID:
+
+```hcl
+data "rollbar_team" "foobar" {
+  name = "foobar"
+}
+
+data "rollbar_team" "example" {
+  team_id = 123456
+}
+```
+
+
+Argument Reference
+------------------
+
+The following arguments are supported:
+
+* `team_id` - (Optional) Rollbar team ID.
+* `name` - (Optional) Human readable name for the team. Conflicts with `team_id`.
+
+One of `team_id` or `name` must be specified.
+
+Attribute Reference
+-------------------
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the team
+* `account_id` - ID of account that owns the team
+* `access_level` - Team access level. Will be one of `standard`, `light` or `view`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ Data Sources
   - An access token belonging to a Rollbar project
 * [`rollbar_project_access_tokens`](data-sources/project_access_tokens.md)
   - List all access tokens belonging to a Rollbar project
+* [`rollbar_team`](data-sources/team.md) - A Rollbar team
 
 
 Resources

--- a/example/data-sources.tf
+++ b/example/data-sources.tf
@@ -38,3 +38,11 @@ data "rollbar_project_access_token" "test_token_1" {
   name       = "test-token-1"
   depends_on = [rollbar_project_access_token.test_1]
 }
+
+data "rollbar_team" "test_team_0" {
+  team_id = rollbar_team.test_team_0.id
+}
+
+data "rollbar_team" "test_team_1" {
+  name = "test-team-example"
+}

--- a/rollbar/data_source_team.go
+++ b/rollbar/data_source_team.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2020 Rollbar, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package rollbar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/rollbar/terraform-provider-rollbar/client"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"strconv"
+)
+
+func dataSourceTeam() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTeamRead,
+
+		Schema: map[string]*schema.Schema{
+			"team_id": {
+				Description:   "Team ID",
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+			},
+			"name": {
+				Description: "Name of the team",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+
+			"account_id": {
+				Description: "Account ID",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+
+			"access_level": {
+				Description: "The team's access level",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var team client.Team
+	var l zerolog.Logger
+	teamID, ok := d.GetOk("team_id")
+	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+	if ok {
+		l = log.With().
+			Int("id", teamID.(int)).
+			Logger()
+		l.Debug().Msg("Reading team from Rollbar by ID")
+		respTeam, err := c.ReadTeam(teamID.(int))
+		if err != nil {
+			return diag.Errorf("Team not found by ID: %v", err)
+		}
+		team = respTeam
+	} else {
+		name, nameOk := d.GetOk("name")
+		if !nameOk {
+			return diag.Errorf("Data Source requires either \"name\" or \"team_id\"")
+		}
+		l = log.With().
+			Str("name", name.(string)).
+			Logger()
+		l.Debug().Msg("Reading team from Rollbar by name")
+
+		teams, err := c.ListTeams()
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		t, err := findTeamByName(teams, name.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		team = t
+	}
+
+	d.SetId(strconv.FormatInt(int64(team.ID), 10))
+	_ = d.Set("team_id", team.ID)
+	_ = d.Set("name", team.Name)
+	_ = d.Set("access_level", team.AccessLevel)
+	_ = d.Set("account_id", team.AccountID)
+	return nil
+}
+
+func findTeamByName(teams []client.Team, name string) (client.Team, error) {
+	for _, team := range teams {
+		if team.Name == name {
+			return team, nil
+		}
+	}
+	return client.Team{}, errors.New(fmt.Sprintf("Team not found by name: %s", name))
+}

--- a/rollbar/data_source_team_test.go
+++ b/rollbar/data_source_team_test.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020 Rollbar, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package rollbar
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/rs/zerolog/log"
+	"regexp"
+)
+
+func (s *AccSuite) TestAccTeamDataSource() {
+	rn_name := "data.rollbar_team.test_name"
+	rn_id := "data.rollbar_team.test_id"
+
+	resource.ParallelTest(s.T(), resource.TestCase{
+		PreCheck:     func() { s.preCheck() },
+		Providers:    s.providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					log.Debug().Msg("Testing data source rollbar_team with invalid name")
+				},
+				Config:      s.configDataSourceTeamNotFoundByName(),
+				ExpectError: regexp.MustCompile("Team not found by name"),
+			},
+			{
+				PreConfig: func() {
+					log.Debug().Msg("Testing data source rollbar_team with invalid ID")
+				},
+				Config:      s.configDataSourceTeamNotFoundById(),
+				ExpectError: regexp.MustCompile("Team not found by ID"),
+			},
+			{
+				PreConfig: func() {
+					log.Debug().Msg("Testing data source rollbar_team")
+				},
+				Config: s.configDataSourceTeam(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rn_name, "name", s.randName),
+					resource.TestCheckResourceAttr(rn_id, "name", s.randName),
+					resource.TestCheckResourceAttrSet(rn_name, "id"),
+					resource.TestCheckResourceAttrSet(rn_name, "account_id"),
+					resource.TestCheckResourceAttrSet(rn_name, "access_level"),
+					resource.TestCheckResourceAttrSet(rn_id, "id"),
+					resource.TestCheckResourceAttrSet(rn_id, "account_id"),
+					resource.TestCheckResourceAttrSet(rn_id, "access_level"),
+				),
+			},
+		},
+	})
+}
+
+func (s *AccSuite) configDataSourceTeam() string {
+	// language=hcl
+	tmpl := `
+		resource "rollbar_team" "test" {
+		  name         = "%s"
+		}
+
+		data "rollbar_team" "test_name" {
+			name = "%s"
+			depends_on = [rollbar_team.test]
+		}
+
+        data "rollbar_team" "test_id" {
+            team_id = rollbar_team.test.id
+        }
+	`
+	return fmt.Sprintf(tmpl, s.randName, s.randName)
+}
+
+func (s *AccSuite) configDataSourceTeamNotFoundByName() string {
+	// language=hcl
+	tmpl := `
+		data "rollbar_team" "test" {
+			name = "%s"
+		}
+	`
+	return fmt.Sprintf(tmpl, s.randName)
+}
+
+func (s *AccSuite) configDataSourceTeamNotFoundById() string {
+	// language=hcl
+	tmpl := `
+		data "rollbar_team" "test" {
+			team_id = %d
+		}
+	`
+	return fmt.Sprintf(tmpl, s.randID)
+}

--- a/rollbar/provider.go
+++ b/rollbar/provider.go
@@ -71,6 +71,7 @@ func Provider() *schema.Provider {
 			"rollbar_projects":              dataSourceProjects(),
 			"rollbar_project_access_token":  dataSourceProjectAccessToken(),
 			"rollbar_project_access_tokens": dataSourceProjectAccessTokens(),
+			"rollbar_team":                  dataSourceTeam(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/rollbar/provider_test.go
+++ b/rollbar/provider_test.go
@@ -63,6 +63,7 @@ type AccSuite struct {
 
 	// The following variables are populated before each test by SetupTest():
 	randName string // Name of a Rollbar project
+	randID int // ID of a Rollbar resource
 }
 
 func (s *AccSuite) SetupSuite() {
@@ -88,6 +89,7 @@ func (s *AccSuite) preCheck() {
 func (s *AccSuite) SetupTest() {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	s.randName = fmt.Sprintf("tf-acc-test-%s", randString)
+	s.randID = acctest.RandInt()
 }
 
 func TestAccSuite(t *testing.T) {


### PR DESCRIPTION
## Description of the change

This adds a `rollbar_team` data source that can be used to look up existing teams in Rollbar either by `team_id` or `name`. This could allow looking up a team managed in another terraform module/folder in order to add users to it in a different module/folder.

We manage our Rollbar projects and teams in separate modules/folders. This will help facilitate interdependencies.

I see a task for lint, but am not seeing any linter setup for the project.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
