### PR TITLE
unifying complex import separator

### DIFF
--- a/docs/resources/team_user.md
+++ b/docs/resources/team_user.md
@@ -53,8 +53,8 @@ In addition to all arguments above, the following attributes are exported:
 Import
 ------
 
-Resource can be imported using the team ID and email address separated by a `/` (forward slash) e.g.
+Resource can be imported using the team ID and email address separated by a comma e.g.
 
 ```
-$ terraform import rollbar_team_user.foo 689493/some_dev@company.com
+$ terraform import rollbar_team_user.foo 689493,some_dev@company.com
 ```

--- a/rollbar/const.go
+++ b/rollbar/const.go
@@ -1,0 +1,3 @@
+package rollbar
+
+const ComplexImportSeparator = ","

--- a/rollbar/resource_notification.go
+++ b/rollbar/resource_notification.go
@@ -38,7 +38,7 @@ var configMap = map[string][]string{"email": {"users", "teams"},
 	"pagerduty": {"service_key"}}
 
 func CustomNotificationImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	splitID := strings.Split(d.Id(), ",")
+	splitID := strings.Split(d.Id(), ComplexImportSeparator)
 	if len(splitID) > 1 {
 		mustSet(d, "channel", splitID[0])
 		d.SetId(splitID[1])

--- a/rollbar/resource_team_user.go
+++ b/rollbar/resource_team_user.go
@@ -80,18 +80,18 @@ func resourceTeamUser() *schema.Resource {
 }
 
 func teamUserID(teamID int, email string) string {
-	return fmt.Sprintf("%d/%s", teamID, email)
+	return fmt.Sprintf("%d%s%s", teamID, ComplexImportSeparator, email)
 }
 
 func teamUserFromID(id string) (teamID int, s string, err error) {
 
-	if !strings.Contains(id, "/") {
-		return 0, s, fmt.Errorf("resource ID missing delimiter (/)")
+	if !strings.Contains(id, ComplexImportSeparator) {
+		return 0, s, fmt.Errorf("resource ID missing delimiter (%s)", ComplexImportSeparator)
 	}
 	l := log.With().
 		Str("id", id).
 		Logger()
-	values := strings.SplitN(id, "/", 2)
+	values := strings.SplitN(id, ComplexImportSeparator, 2)
 	l = l.With().Strs("values", values).Logger()
 	l.Debug().Msg("Converting userID to int")
 	teamID, err = strconv.Atoi(values[0])


### PR DESCRIPTION
## Description of the change
Making complex import separator as a comma (",")

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
