### PR TITLE
Add darwin arm64 target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build:
 
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=darwin GOARCH=arm64 go build -o ./bin/${BINARY}_${VERSION}_darwin_arm64
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
 	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
 	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm
@@ -36,12 +37,12 @@ install012: build
 	mkdir -p ~/.terraform.d/plugins/${OS_ARCH}/
 	mv ${BINARY} ~/.terraform.d/plugins/${OS_ARCH}/terraform-provider-${NAME}_v${VERSION}
 
-test: 
+test:
 	go test -covermode=atomic -coverprofile=coverage.out $(TEST) || exit 1
-	@#echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
+	@#echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
-testacc: 
-	TF_ACC=1 TERRAFORM_PROVIDER_ROLLBAR_DEBUG=1 go test -covermode=atomic -coverprofile=coverage.out $(TEST) -v $(TESTARGS) -timeout 120m   
+testacc:
+	TF_ACC=1 TERRAFORM_PROVIDER_ROLLBAR_DEBUG=1 go test -covermode=atomic -coverprofile=coverage.out $(TEST) -v $(TESTARGS) -timeout 120m
 
 slscan:
 	./.slscan.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rollbar/terraform-provider-rollbar
 
-go 1.15
+go 1.16
 
 // Until https://github.com/rs/zerolog/pull/266 or https://github.com/rs/zerolog/pull/267
 // is included in the next release


### PR DESCRIPTION
## Description of the change

Adds arm64 as an architecture for darwin goos

This will make it possible for someone on macos silicon to use this provider

## Type of change

- [ ] New feature (non-breaking change that adds functionality)

## Related issues

Resolves #261 

- Fix #261

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
