### PR TITLE
add mutex to read/write http headers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,6 +25,7 @@ package client
 
 import (
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -34,6 +35,8 @@ import (
 // DefaultBaseURL is the default base URL for the Rollbar API.
 const DefaultBaseURL = "https://api.rollbar.com"
 const Version = "v1.10.0"
+
+var Mutex sync.Mutex
 
 // RollbarAPIClient is a client for the Rollbar API.
 type RollbarAPIClient struct {
@@ -67,6 +70,7 @@ func NewClient(baseURL, token string) *RollbarAPIClient {
 					r.StatusCode() == http.StatusBadGateway
 			})
 	// Authentication
+	Mutex.Lock()
 	if token != "" {
 		r = r.SetHeaders(map[string]string{
 			"X-Rollbar-Access-Token":      token,
@@ -76,7 +80,7 @@ func NewClient(baseURL, token string) *RollbarAPIClient {
 	} else {
 		log.Warn().Msg("Rollbar API token not set")
 	}
-
+	Mutex.Unlock()
 	// Authentication
 	if baseURL == "" {
 		log.Error().Msg("Rollbar API base URL not set")

--- a/rollbar/common.go
+++ b/rollbar/common.go
@@ -23,8 +23,6 @@
 package rollbar
 
 import (
-	"sync"
-
 	"github.com/rollbar/terraform-provider-rollbar/client"
 )
 
@@ -43,15 +41,9 @@ const (
 	rollbarIntegration         = "rollbar_integration"
 )
 
-var lock sync.Mutex
-
 func setResourceHeader(header string, c *client.RollbarAPIClient) {
-	lock.Lock()
-	defer lock.Unlock()
 	c.Resty.SetHeader("X-Rollbar-Terraform-Resource", header)
 }
 func setDataSourceHeader(header string, c *client.RollbarAPIClient) {
-	lock.Lock()
-	defer lock.Unlock()
 	c.Resty.SetHeader("X-Rollbar-Terraform-DataSource", header)
 }

--- a/rollbar/data_source_project.go
+++ b/rollbar/data_source_project.go
@@ -74,8 +74,10 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+	client.Mutex.Lock()
 	setDataSourceHeader(rollbarProject, c)
 	pl, err := c.ListProjects()
+	client.Mutex.Unlock()
 	if err != nil {
 		return err
 	}

--- a/rollbar/data_source_project_access_token.go
+++ b/rollbar/data_source_project_access_token.go
@@ -118,8 +118,10 @@ func dataSourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceDat
 	l.Debug().Msg("Reading project access token from Rollbar")
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+	client.Mutex.Lock()
 	setDataSourceHeader(rollbarProjectAccessToken, c)
 	tokens, err := c.ListProjectAccessTokens(projectID)
+	client.Mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rollbar/data_source_project_access_tokens.go
+++ b/rollbar/data_source_project_access_tokens.go
@@ -135,8 +135,10 @@ func dataSourceProjectAccessTokensRead(ctx context.Context, d *schema.ResourceDa
 	l.Debug().Msg("Reading project access token data from Rollbar")
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+	client.Mutex.Lock()
 	setDataSourceHeader(rollbarProjectAccessTokens, c)
 	tokens, err := c.ListProjectAccessTokens(projectID)
+	client.Mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rollbar/data_source_projects.go
+++ b/rollbar/data_source_projects.go
@@ -84,9 +84,12 @@ func dataSourceProjectsRead(ctx context.Context, d *schema.ResourceData, m inter
 	log.Debug().Msg("Reading project list from API")
 	var diags diag.Diagnostics
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
-	setDataSourceHeader(rollbarProjects, c)
 
+	client.Mutex.Lock()
+	setDataSourceHeader(rollbarProjects, c)
 	projects, err := c.ListProjects()
+	client.Mutex.Unlock()
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rollbar/data_source_team.go
+++ b/rollbar/data_source_team.go
@@ -71,6 +71,8 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface
 	var l zerolog.Logger
 	teamID, ok := d.GetOk("team_id")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
 	setDataSourceHeader(rollbarTeam, c)
 
 	if ok {
@@ -104,7 +106,7 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface
 		}
 		team = t
 	}
-
+	client.Mutex.Unlock()
 	d.SetId(strconv.FormatInt(int64(team.ID), 10))
 	_ = d.Set("team_id", team.ID)
 	_ = d.Set("name", team.Name)

--- a/rollbar/resource_integration.go
+++ b/rollbar/resource_integration.go
@@ -241,9 +241,12 @@ func resourceIntegrationCreateUpdateDelete(integration string, bodyMap map[strin
 		l = l.With().Str("id", id).Logger()
 	}
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
-	setResourceHeader(rollbarIntegration, c)
 
+	client.Mutex.Lock()
+	setResourceHeader(rollbarIntegration, c)
 	intf, err := c.UpdateIntegration(integration, bodyMap)
+	client.Mutex.Unlock()
+
 	if err != nil {
 		l.Err(err).Send()
 		if action == CREATE || action == UPDATE {
@@ -340,9 +343,12 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, m inte
 	integration := spl[1]
 	l.Info().Msg("Reading rollbar_integration resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
-	setResourceHeader(rollbarIntegration, c)
 
+	client.Mutex.Lock()
+	setResourceHeader(rollbarIntegration, c)
 	intf, err := c.ReadIntegration(integration)
+	client.Mutex.Unlock()
+	
 	if err == client.ErrNotFound {
 		d.SetId("")
 		l.Info().Msg("Integration not found - removed from state")

--- a/rollbar/resource_notification.go
+++ b/rollbar/resource_notification.go
@@ -274,8 +274,12 @@ func resourceNotificationCreate(ctx context.Context, d *schema.ResourceData, m i
 	l.Info().Msg("Creating rollbar_notification resource")
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarNotification, c)
 	n, err := c.CreateNotification(channel, filters, trigger, config)
+	client.Mutex.Unlock()
+
 	if err != nil {
 		l.Err(err).Send()
 		d.SetId("") // removing from the state
@@ -301,8 +305,10 @@ func resourceNotificationUpdate(ctx context.Context, d *schema.ResourceData, m i
 	l.Info().Msg("Creating rollbar_notification resource")
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
+	client.Mutex.Lock()
 	setResourceHeader(rollbarNotification, c)
 	n, err := c.UpdateNotification(id, channel, filters, trigger, config)
+	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Send()
@@ -370,8 +376,12 @@ func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, m int
 		Logger()
 	l.Info().Msg("Reading rollbar_notification resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarNotification, c)
 	n, err := c.ReadNotification(id, channel)
+	client.Mutex.Unlock()
+
 	if err == client.ErrNotFound {
 		d.SetId("")
 		l.Info().Msg("Notification not found - removed from state")
@@ -394,8 +404,12 @@ func resourceNotificationDelete(ctx context.Context, d *schema.ResourceData, m i
 	l := log.With().Int("id", id).Logger()
 	l.Info().Msg("Deleting rollbar_notification resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarNotification, c)
 	err := c.DeleteNotification(id, channel)
+	client.Mutex.Unlock()
+	
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_notification resource")
 		return diag.FromErr(err)

--- a/rollbar/resource_project.go
+++ b/rollbar/resource_project.go
@@ -94,8 +94,12 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 	l.Info().Msg("Creating new Rollbar project resource")
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarProject, c)
 	p, err := c.CreateProject(name)
+	client.Mutex.Unlock()
+
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
@@ -163,8 +167,12 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 	l.Info().Msg("Reading Rollbar project resource")
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarProject, c)
 	proj, err := c.ReadProject(projectID)
+	client.Mutex.Unlock()
+
 	if err == client.ErrNotFound {
 		l.Debug().Msg("Project not found on Rollbar - removing from state")
 		d.SetId("")
@@ -206,8 +214,12 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		Logger()
 	l.Debug().Msg("Updating rollbar_project resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarProject, c)
 	err := c.UpdateProjectTeams(projectID, teamIDs)
+	client.Mutex.Unlock()
+
 	if err != nil {
 		l.Err(err).Msg("Error updating rollbar_project resource")
 		return diag.FromErr(err)
@@ -224,8 +236,12 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interf
 		Logger()
 	l.Info().Msg("Deleting rollbar_project resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarProject, c)
 	err := c.DeleteProject(projectID)
+	client.Mutex.Unlock()
+
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_project resource")
 		return diag.FromErr(err)

--- a/rollbar/resource_project.go
+++ b/rollbar/resource_project.go
@@ -119,7 +119,9 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 		"post_client_item": true,
 		"post_server_item": true,
 	}
+	client.Mutex.Lock()
 	tokens, err := c.ListProjectAccessTokens(projectID)
+	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
@@ -133,7 +135,9 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 			return diag.FromErr(err)
 		}
 		// Deletion
+		client.Mutex.Lock()
 		err = c.DeleteProjectAccessToken(projectID, t.AccessToken)
+		client.Mutex.Unlock()
 		if err != nil {
 			l.Err(err).Send()
 			return diag.FromErr(err)
@@ -148,7 +152,9 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 	for _, teamIDiface := range teamIDsSet.List() {
 		teamID := teamIDiface.(int)
 		l = l.With().Int("team_id", teamID).Logger()
+		client.Mutex.Lock()
 		err = c.AssignTeamToProject(teamID, projectID)
+		client.Mutex.Unlock()
 		if err != nil {
 			l.Err(err).Send()
 			return diag.FromErr(err)
@@ -191,8 +197,9 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 		}
 		mustSet(d, k, v)
 	}
-
+	client.Mutex.Lock()
 	teamIDs, err := c.FindProjectTeamIDs(projectID)
+	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)

--- a/rollbar/resource_service_link.go
+++ b/rollbar/resource_service_link.go
@@ -67,9 +67,12 @@ func resourceServiceLinkCreate(ctx context.Context, d *schema.ResourceData, m in
 	l.Info().Msg("Creating rollbar_service_link resource")
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
-	setResourceHeader(rollbarServiceLink, c)
 
+	client.Mutex.Lock()
+	setResourceHeader(rollbarServiceLink, c)
 	sl, err := c.CreateServiceLink(name, template)
+	client.Mutex.Unlock()
+
 	if err != nil {
 		l.Err(err).Send()
 		d.SetId("") // removing from the state
@@ -94,9 +97,11 @@ func resourceServiceLinkUpdate(ctx context.Context, d *schema.ResourceData, m in
 	l.Info().Msg("Creating rollbar_service_link resource")
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
-	setResourceHeader(rollbarServiceLink, c)
 
+	client.Mutex.Lock()
+	setResourceHeader(rollbarServiceLink, c)
 	sl, err := c.UpdateServiceLink(id, name, template)
+	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Send()
@@ -122,9 +127,12 @@ func resourceServiceLinkRead(ctx context.Context, d *schema.ResourceData, m inte
 		Logger()
 	l.Info().Msg("Reading rollbar_service_link resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
-	setResourceHeader(rollbarServiceLink, c)
 
+	client.Mutex.Lock()
+	setResourceHeader(rollbarServiceLink, c)
 	sl, err := c.ReadServiceLink(id)
+	client.Mutex.Unlock()
+
 	if err == client.ErrNotFound {
 		d.SetId("")
 		l.Info().Msg("Service Link not found - removed from state")
@@ -146,9 +154,12 @@ func resourceServiceLinkDelete(ctx context.Context, d *schema.ResourceData, m in
 	l := log.With().Int("id", id).Logger()
 	l.Info().Msg("Deleting rollbar_service_link resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
-	setResourceHeader(rollbarServiceLink, c)
 
+	client.Mutex.Lock()
+	setResourceHeader(rollbarServiceLink, c)
 	err := c.DeleteServiceLink(id)
+	client.Mutex.Unlock()
+	
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_service_link resource")
 		return diag.FromErr(err)

--- a/rollbar/resource_team.go
+++ b/rollbar/resource_team.go
@@ -97,9 +97,12 @@ func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, m interface
 	l := log.With().Str("name", name).Str("access_level", level).Logger()
 	l.Info().Msg("Creating rollbar_team resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
-	setResourceHeader(rollbarTeam, c)
 
+	client.Mutex.Lock()
+	setResourceHeader(rollbarTeam, c)
 	t, err := c.CreateTeam(name, level)
+	client.Mutex.Unlock()
+
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
@@ -118,8 +121,12 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		Logger()
 	l.Info().Msg("Reading rollbar_team resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarTeam, c)
 	t, err := c.ReadTeam(id)
+	client.Mutex.Unlock()
+
 	if err == client.ErrNotFound {
 		d.SetId("")
 		l.Err(err).Msg("Team not found - removed from state")
@@ -142,8 +149,12 @@ func resourceTeamDelete(ctx context.Context, d *schema.ResourceData, m interface
 	l := log.With().Int("id", id).Logger()
 	l.Info().Msg("Deleting rollbar_team resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarTeam, c)
 	err := c.DeleteTeam(id)
+	client.Mutex.Unlock()
+
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_team resource")
 		return diag.FromErr(err)

--- a/rollbar/resource_team_user.go
+++ b/rollbar/resource_team_user.go
@@ -104,7 +104,6 @@ func teamUserFromID(id string) (teamID int, s string, err error) {
 
 func resourceTeamUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
-	setResourceHeader(rollbarTeamUser, c)
 	teamID := d.Get("team_id").(int)
 	email := d.Get("email").(string)
 	l := log.With().
@@ -114,14 +113,20 @@ func resourceTeamUserCreate(ctx context.Context, d *schema.ResourceData, meta in
 	l.Info().Msg("Creating rollbar_team_user resource")
 
 	// Check if a Rollbar user exists for this email
+	client.Mutex.Lock()
+	setResourceHeader(rollbarTeamUser, c)
 	userID, err := c.FindUserID(email)
+	client.Mutex.Unlock()
+
 	l = l.With().Int("user_id", userID).Logger()
 	switch err {
 	case nil: // User Found, assign them to the team
 		l.Debug().Msg("Found existing user")
 		mustSet(d, "user_id", userID)
 		mustSet(d, "status", "registered")
+		client.Mutex.Lock()
 		er := c.AssignUserToTeam(teamID, userID)
+		client.Mutex.Unlock()
 		if er != nil {
 			l.Err(er).Msg("error assigning user to team")
 			return diag.FromErr(er)
@@ -131,7 +136,9 @@ func resourceTeamUserCreate(ctx context.Context, d *schema.ResourceData, meta in
 	case client.ErrNotFound: // User not found, send an invitation
 		l.Debug().Msg("Existing user not found")
 		mustSet(d, "status", "invited")
+		client.Mutex.Lock()
 		inv, er := c.CreateInvitation(teamID, email)
+		client.Mutex.Unlock()
 		if er != nil {
 			l.Err(er).Msg("error assigning user to team")
 			return diag.FromErr(er)
@@ -163,11 +170,16 @@ func resourceTeamUserRead(_ context.Context, d *schema.ResourceData, meta interf
 		Logger()
 	l.Info().Msg("Reading rollbar_team_user resource")
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarTeamUser, c)
+	client.Mutex.Unlock()
 
 	// If user ID is not in state, try to query it from Rollbar
 	if userID == 0 {
+		client.Mutex.Lock()
 		userID, err = c.FindUserID(email)
+		client.Mutex.Unlock()
 		switch err {
 		case nil:
 			l = log.With().
@@ -188,7 +200,9 @@ func resourceTeamUserRead(_ context.Context, d *schema.ResourceData, meta interf
 
 	if userID != 0 {
 		// Check if user is assigned to the team
+		client.Mutex.Lock()
 		assigned, err := c.IsUserAssignedToTeam(teamID, userID)
+		client.Mutex.Unlock()
 		if err != nil {
 			l.Err(err).Msg("Error checking if user is assigned to team.")
 			return diag.FromErr(err)
@@ -201,7 +215,9 @@ func resourceTeamUserRead(_ context.Context, d *schema.ResourceData, meta interf
 		_ = d.Set("invite_id", nil)
 	} else {
 		// Check if user is invited to the team
+		client.Mutex.Lock()
 		invitations, err := c.ListPendingInvitations(teamID)
+		client.Mutex.Unlock()
 		if err != nil {
 			l.Err(err).Msg("Error checking if user has pending invitation.")
 			return diag.FromErr(err)
@@ -231,20 +247,27 @@ func resourceTeamUserDelete(_ context.Context, d *schema.ResourceData, meta inte
 		Logger()
 	l.Info().Msg("Deleting rollbar_team_user resource")
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
 	setResourceHeader(rollbarTeamUser, c)
+	client.Mutex.Unlock()
 
 	userID := d.Get("user_id").(int)
 	if userID == 0 {
 		// Cancel invitation
 		inviteID := d.Get("invite_id").(int)
+		client.Mutex.Lock()
 		err := c.CancelInvitation(inviteID)
+		client.Mutex.Unlock()
 		if err != client.ErrNotFound {
 			l.Err(err).Send()
 			return diag.FromErr(err)
 		}
 	} else {
 		// Remove user from team
+		client.Mutex.Lock()
 		err := c.RemoveUserFromTeam(userID, teamID)
+		client.Mutex.Unlock()
 		if err != nil {
 			if err != client.ErrNotFound {
 				l.Err(err).Send()

--- a/rollbar/resource_user.go
+++ b/rollbar/resource_user.go
@@ -97,6 +97,9 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 // specified.
 func resourceUserCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+
+	client.Mutex.Lock()
+	defer client.Mutex.Unlock()
 	setResourceHeader(rollbarUser, c)
 	email := d.Get("email").(string)
 	teamIDs := getTeamIDs(d)
@@ -326,6 +329,8 @@ func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{
 		Logger()
 	l.Info().Msg("Reading rollbar_user resource")
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+	client.Mutex.Lock()
+	defer client.Mutex.Unlock()
 	setResourceHeader(rollbarUser, c)
 	var err error
 
@@ -387,6 +392,8 @@ func resourceUserDelete(_ context.Context, d *schema.ResourceData, meta interfac
 		Logger()
 	l.Info().Msg("Deleting rollbar_user resource")
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+	client.Mutex.Lock()
+	defer client.Mutex.Unlock()
 	setResourceHeader(rollbarUser, c)
 
 	// Try to get user ID
@@ -441,6 +448,8 @@ func resourceUserImporter(ctx context.Context, d *schema.ResourceData, meta inte
 
 	teamIDs := []int{}
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
+	client.Mutex.Lock()
+	defer client.Mutex.Unlock()
 	setResourceHeader(rollbarUser, c)
 
 	invitations, err := c.FindInvitations(email)


### PR DESCRIPTION
## Description of the change

Adding a proper mutex to read/write http headers.

Note for the reviewer: 
I tried to optimize the code by locking/unlocking the mutex explicitly exactly when it was needed (overall execution little bit faster), instead of deferring unlocking, which would make the code more elegant and easier to read. (overall execution little bit slower). Please let me know which way you would prefer.  

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)


- Fix #346

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
