### PR TITLE
removed Resource and DataSource http header (no mutex)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,7 +25,6 @@ package client
 
 import (
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -35,8 +34,6 @@ import (
 // DefaultBaseURL is the default base URL for the Rollbar API.
 const DefaultBaseURL = "https://api.rollbar.com"
 const Version = "v1.13.0"
-
-var Mutex sync.Mutex
 
 // RollbarAPIClient is a client for the Rollbar API.
 type RollbarAPIClient struct {
@@ -70,7 +67,6 @@ func NewClient(baseURL, token string) *RollbarAPIClient {
 					r.StatusCode() == http.StatusBadGateway
 			})
 	// Authentication
-	Mutex.Lock()
 	if token != "" {
 		r = r.SetHeaders(map[string]string{
 			"X-Rollbar-Access-Token":      token,
@@ -80,7 +76,6 @@ func NewClient(baseURL, token string) *RollbarAPIClient {
 	} else {
 		log.Warn().Msg("Rollbar API token not set")
 	}
-	Mutex.Unlock()
 	// Authentication
 	if baseURL == "" {
 		log.Error().Msg("Rollbar API base URL not set")

--- a/rollbar/common.go
+++ b/rollbar/common.go
@@ -22,10 +22,6 @@
 
 package rollbar
 
-import (
-	"github.com/rollbar/terraform-provider-rollbar/client"
-)
-
 const ComplexImportSeparator = ","
 
 const (
@@ -40,10 +36,3 @@ const (
 	rollbarServiceLink         = "rollbar_service_link"
 	rollbarIntegration         = "rollbar_integration"
 )
-
-func setResourceHeader(header string, c *client.RollbarAPIClient) {
-	c.Resty.SetHeader("X-Rollbar-Terraform-Resource", header)
-}
-func setDataSourceHeader(header string, c *client.RollbarAPIClient) {
-	c.Resty.SetHeader("X-Rollbar-Terraform-DataSource", header)
-}

--- a/rollbar/data_source_project.go
+++ b/rollbar/data_source_project.go
@@ -74,10 +74,7 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
-	client.Mutex.Lock()
-	setDataSourceHeader(rollbarProject, c)
 	pl, err := c.ListProjects()
-	client.Mutex.Unlock()
 	if err != nil {
 		return err
 	}

--- a/rollbar/data_source_project_access_token.go
+++ b/rollbar/data_source_project_access_token.go
@@ -118,10 +118,7 @@ func dataSourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceDat
 	l.Debug().Msg("Reading project access token from Rollbar")
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
-	client.Mutex.Lock()
-	setDataSourceHeader(rollbarProjectAccessToken, c)
 	tokens, err := c.ListProjectAccessTokens(projectID)
-	client.Mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rollbar/data_source_project_access_tokens.go
+++ b/rollbar/data_source_project_access_tokens.go
@@ -135,10 +135,7 @@ func dataSourceProjectAccessTokensRead(ctx context.Context, d *schema.ResourceDa
 	l.Debug().Msg("Reading project access token data from Rollbar")
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
-	client.Mutex.Lock()
-	setDataSourceHeader(rollbarProjectAccessTokens, c)
 	tokens, err := c.ListProjectAccessTokens(projectID)
-	client.Mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rollbar/data_source_projects.go
+++ b/rollbar/data_source_projects.go
@@ -85,10 +85,7 @@ func dataSourceProjectsRead(ctx context.Context, d *schema.ResourceData, m inter
 	var diags diag.Diagnostics
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setDataSourceHeader(rollbarProjects, c)
 	projects, err := c.ListProjects()
-	client.Mutex.Unlock()
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/rollbar/data_source_team.go
+++ b/rollbar/data_source_team.go
@@ -72,9 +72,6 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface
 	teamID, ok := d.GetOk("team_id")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setDataSourceHeader(rollbarTeam, c)
-
 	if ok {
 		l = log.With().
 			Int("id", teamID.(int)).
@@ -106,7 +103,6 @@ func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface
 		}
 		team = t
 	}
-	client.Mutex.Unlock()
 	d.SetId(strconv.FormatInt(int64(team.ID), 10))
 	_ = d.Set("team_id", team.ID)
 	_ = d.Set("name", team.Name)

--- a/rollbar/resource_integration.go
+++ b/rollbar/resource_integration.go
@@ -242,10 +242,7 @@ func resourceIntegrationCreateUpdateDelete(integration string, bodyMap map[strin
 	}
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarIntegration, c)
 	intf, err := c.UpdateIntegration(integration, bodyMap)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Send()
@@ -344,11 +341,7 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, m inte
 	l.Info().Msg("Reading rollbar_integration resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarIntegration, c)
 	intf, err := c.ReadIntegration(integration)
-	client.Mutex.Unlock()
-	
 	if err == client.ErrNotFound {
 		d.SetId("")
 		l.Info().Msg("Integration not found - removed from state")

--- a/rollbar/resource_notification.go
+++ b/rollbar/resource_notification.go
@@ -275,10 +275,7 @@ func resourceNotificationCreate(ctx context.Context, d *schema.ResourceData, m i
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarNotification, c)
 	n, err := c.CreateNotification(channel, filters, trigger, config)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Send()
@@ -305,10 +302,7 @@ func resourceNotificationUpdate(ctx context.Context, d *schema.ResourceData, m i
 	l.Info().Msg("Creating rollbar_notification resource")
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
-	client.Mutex.Lock()
-	setResourceHeader(rollbarNotification, c)
 	n, err := c.UpdateNotification(id, channel, filters, trigger, config)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Send()
@@ -377,10 +371,7 @@ func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, m int
 	l.Info().Msg("Reading rollbar_notification resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarNotification, c)
 	n, err := c.ReadNotification(id, channel)
-	client.Mutex.Unlock()
 
 	if err == client.ErrNotFound {
 		d.SetId("")
@@ -405,11 +396,7 @@ func resourceNotificationDelete(ctx context.Context, d *schema.ResourceData, m i
 	l.Info().Msg("Deleting rollbar_notification resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarNotification, c)
 	err := c.DeleteNotification(id, channel)
-	client.Mutex.Unlock()
-	
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_notification resource")
 		return diag.FromErr(err)

--- a/rollbar/resource_project.go
+++ b/rollbar/resource_project.go
@@ -95,10 +95,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarProject, c)
 	p, err := c.CreateProject(name)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Send()
@@ -119,9 +116,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 		"post_client_item": true,
 		"post_server_item": true,
 	}
-	client.Mutex.Lock()
 	tokens, err := c.ListProjectAccessTokens(projectID)
-	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
@@ -135,9 +130,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 			return diag.FromErr(err)
 		}
 		// Deletion
-		client.Mutex.Lock()
 		err = c.DeleteProjectAccessToken(projectID, t.AccessToken)
-		client.Mutex.Unlock()
 		if err != nil {
 			l.Err(err).Send()
 			return diag.FromErr(err)
@@ -152,9 +145,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 	for _, teamIDiface := range teamIDsSet.List() {
 		teamID := teamIDiface.(int)
 		l = l.With().Int("team_id", teamID).Logger()
-		client.Mutex.Lock()
 		err = c.AssignTeamToProject(teamID, projectID)
-		client.Mutex.Unlock()
 		if err != nil {
 			l.Err(err).Send()
 			return diag.FromErr(err)
@@ -174,10 +165,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarProject, c)
 	proj, err := c.ReadProject(projectID)
-	client.Mutex.Unlock()
 
 	if err == client.ErrNotFound {
 		l.Debug().Msg("Project not found on Rollbar - removing from state")
@@ -197,9 +185,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 		}
 		mustSet(d, k, v)
 	}
-	client.Mutex.Lock()
 	teamIDs, err := c.FindProjectTeamIDs(projectID)
-	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
@@ -222,10 +208,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	l.Debug().Msg("Updating rollbar_project resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarProject, c)
 	err := c.UpdateProjectTeams(projectID, teamIDs)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Msg("Error updating rollbar_project resource")
@@ -244,10 +227,7 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interf
 	l.Info().Msg("Deleting rollbar_project resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarProject, c)
 	err := c.DeleteProject(projectID)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_project resource")

--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -142,8 +142,6 @@ func resourceProjectAccessTokenCreate(ctx context.Context, d *schema.ResourceDat
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarProjectAccessToken, c)
 	pat, err := c.CreateProjectAccessToken(client.ProjectAccessTokenCreateArgs{
 		Name:                 name,
 		ProjectID:            projectID,
@@ -152,7 +150,6 @@ func resourceProjectAccessTokenCreate(ctx context.Context, d *schema.ResourceDat
 		RateLimitWindowSize:  size,
 		RateLimitWindowCount: count,
 	})
-	client.Mutex.Unlock()
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -175,10 +172,7 @@ func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData,
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarProjectAccessToken, c)
 	pat, err := c.ReadProjectAccessToken(projectID, accessToken)
-	client.Mutex.Unlock()
 
 	if err == client.ErrNotFound {
 		d.SetId("")
@@ -213,10 +207,7 @@ func resourceProjectAccessTokenUpdate(ctx context.Context, d *schema.ResourceDat
 	l.Debug().Msg("Updating resource project access token")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarProjectAccessToken, c)
 	err := c.UpdateProjectAccessToken(args)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		log.Err(err).Send()
@@ -238,11 +229,7 @@ func resourceProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceDat
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarProjectAccessToken, c)
 	err := c.DeleteProjectAccessToken(projectID, accessToken)
-	client.Mutex.Unlock()
-	
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/rollbar/resource_service_link.go
+++ b/rollbar/resource_service_link.go
@@ -68,10 +68,7 @@ func resourceServiceLinkCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarServiceLink, c)
 	sl, err := c.CreateServiceLink(name, template)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Send()
@@ -98,10 +95,7 @@ func resourceServiceLinkUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarServiceLink, c)
 	sl, err := c.UpdateServiceLink(id, name, template)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Send()
@@ -128,10 +122,7 @@ func resourceServiceLinkRead(ctx context.Context, d *schema.ResourceData, m inte
 	l.Info().Msg("Reading rollbar_service_link resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarServiceLink, c)
 	sl, err := c.ReadServiceLink(id)
-	client.Mutex.Unlock()
 
 	if err == client.ErrNotFound {
 		d.SetId("")
@@ -155,11 +146,7 @@ func resourceServiceLinkDelete(ctx context.Context, d *schema.ResourceData, m in
 	l.Info().Msg("Deleting rollbar_service_link resource")
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarServiceLink, c)
 	err := c.DeleteServiceLink(id)
-	client.Mutex.Unlock()
-	
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_service_link resource")
 		return diag.FromErr(err)

--- a/rollbar/resource_team.go
+++ b/rollbar/resource_team.go
@@ -98,10 +98,7 @@ func resourceTeamCreate(ctx context.Context, d *schema.ResourceData, m interface
 	l.Info().Msg("Creating rollbar_team resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarTeam, c)
 	t, err := c.CreateTeam(name, level)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Send()
@@ -122,10 +119,7 @@ func resourceTeamRead(ctx context.Context, d *schema.ResourceData, m interface{}
 	l.Info().Msg("Reading rollbar_team resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarTeam, c)
 	t, err := c.ReadTeam(id)
-	client.Mutex.Unlock()
 
 	if err == client.ErrNotFound {
 		d.SetId("")
@@ -150,10 +144,7 @@ func resourceTeamDelete(ctx context.Context, d *schema.ResourceData, m interface
 	l.Info().Msg("Deleting rollbar_team resource")
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarTeam, c)
 	err := c.DeleteTeam(id)
-	client.Mutex.Unlock()
 
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_team resource")

--- a/rollbar/resource_team_user.go
+++ b/rollbar/resource_team_user.go
@@ -113,10 +113,7 @@ func resourceTeamUserCreate(ctx context.Context, d *schema.ResourceData, meta in
 	l.Info().Msg("Creating rollbar_team_user resource")
 
 	// Check if a Rollbar user exists for this email
-	client.Mutex.Lock()
-	setResourceHeader(rollbarTeamUser, c)
 	userID, err := c.FindUserID(email)
-	client.Mutex.Unlock()
 
 	l = l.With().Int("user_id", userID).Logger()
 	switch err {
@@ -124,9 +121,7 @@ func resourceTeamUserCreate(ctx context.Context, d *schema.ResourceData, meta in
 		l.Debug().Msg("Found existing user")
 		mustSet(d, "user_id", userID)
 		mustSet(d, "status", "registered")
-		client.Mutex.Lock()
 		er := c.AssignUserToTeam(teamID, userID)
-		client.Mutex.Unlock()
 		if er != nil {
 			l.Err(er).Msg("error assigning user to team")
 			return diag.FromErr(er)
@@ -136,9 +131,7 @@ func resourceTeamUserCreate(ctx context.Context, d *schema.ResourceData, meta in
 	case client.ErrNotFound: // User not found, send an invitation
 		l.Debug().Msg("Existing user not found")
 		mustSet(d, "status", "invited")
-		client.Mutex.Lock()
 		inv, er := c.CreateInvitation(teamID, email)
-		client.Mutex.Unlock()
 		if er != nil {
 			l.Err(er).Msg("error assigning user to team")
 			return diag.FromErr(er)
@@ -171,15 +164,9 @@ func resourceTeamUserRead(_ context.Context, d *schema.ResourceData, meta interf
 	l.Info().Msg("Reading rollbar_team_user resource")
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarTeamUser, c)
-	client.Mutex.Unlock()
-
 	// If user ID is not in state, try to query it from Rollbar
 	if userID == 0 {
-		client.Mutex.Lock()
 		userID, err = c.FindUserID(email)
-		client.Mutex.Unlock()
 		switch err {
 		case nil:
 			l = log.With().
@@ -200,9 +187,7 @@ func resourceTeamUserRead(_ context.Context, d *schema.ResourceData, meta interf
 
 	if userID != 0 {
 		// Check if user is assigned to the team
-		client.Mutex.Lock()
 		assigned, err := c.IsUserAssignedToTeam(teamID, userID)
-		client.Mutex.Unlock()
 		if err != nil {
 			l.Err(err).Msg("Error checking if user is assigned to team.")
 			return diag.FromErr(err)
@@ -215,9 +200,7 @@ func resourceTeamUserRead(_ context.Context, d *schema.ResourceData, meta interf
 		_ = d.Set("invite_id", nil)
 	} else {
 		// Check if user is invited to the team
-		client.Mutex.Lock()
 		invitations, err := c.ListPendingInvitations(teamID)
-		client.Mutex.Unlock()
 		if err != nil {
 			l.Err(err).Msg("Error checking if user has pending invitation.")
 			return diag.FromErr(err)
@@ -248,26 +231,18 @@ func resourceTeamUserDelete(_ context.Context, d *schema.ResourceData, meta inte
 	l.Info().Msg("Deleting rollbar_team_user resource")
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarTeamUser, c)
-	client.Mutex.Unlock()
-
 	userID := d.Get("user_id").(int)
 	if userID == 0 {
 		// Cancel invitation
 		inviteID := d.Get("invite_id").(int)
-		client.Mutex.Lock()
 		err := c.CancelInvitation(inviteID)
-		client.Mutex.Unlock()
 		if err != client.ErrNotFound {
 			l.Err(err).Send()
 			return diag.FromErr(err)
 		}
 	} else {
 		// Remove user from team
-		client.Mutex.Lock()
 		err := c.RemoveUserFromTeam(userID, teamID)
-		client.Mutex.Unlock()
 		if err != nil {
 			if err != client.ErrNotFound {
 				l.Err(err).Send()

--- a/rollbar/resource_user.go
+++ b/rollbar/resource_user.go
@@ -98,8 +98,6 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 func resourceUserCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 
-	client.Mutex.Lock()
-	setResourceHeader(rollbarUser, c)
 	email := d.Get("email").(string)
 	teamIDs := getTeamIDs(d)
 	l := log.With().
@@ -110,7 +108,6 @@ func resourceUserCreateOrUpdate(ctx context.Context, d *schema.ResourceData, met
 
 	// Check if a Rollbar user exists for this email
 	userID, err := c.FindUserID(email)
-	client.Mutex.Unlock()
 	l = l.With().Int("user_id", userID).Logger()
 	switch err {
 	case nil:
@@ -131,14 +128,11 @@ func resourceUserCreateOrUpdate(ctx context.Context, d *schema.ResourceData, met
 		teamsExpected[id] = true
 	}
 
-	client.Mutex.Lock()
 	teamsCurrent, err := resourceUserCurrentTeams(c, email, userID, true)
-	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
 	}
-	client.Mutex.Lock()
 	err = resourceUserAddTeams(resourceUserAddRemoveTeamsArgs{
 		client:        c,
 		userID:        userID,
@@ -146,12 +140,10 @@ func resourceUserCreateOrUpdate(ctx context.Context, d *schema.ResourceData, met
 		teamsExpected: teamsExpected,
 		teamsCurrent:  teamsCurrent,
 	})
-	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
 	}
-	client.Mutex.Lock()
 	err = resourceUserRemoveTeams(resourceUserAddRemoveTeamsArgs{
 		client:        c,
 		userID:        userID,
@@ -159,7 +151,6 @@ func resourceUserCreateOrUpdate(ctx context.Context, d *schema.ResourceData, met
 		teamsExpected: teamsExpected,
 		teamsCurrent:  teamsCurrent,
 	})
-	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
@@ -333,16 +324,11 @@ func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{
 		Logger()
 	l.Info().Msg("Reading rollbar_user resource")
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
-	client.Mutex.Lock()
-	setResourceHeader(rollbarUser, c)
-	client.Mutex.Unlock()
 	var err error
 
 	// If user ID is not in state, try to query it from Rollbar
 	if userID == 0 {
-		client.Mutex.Lock()
 		userID, err = c.FindUserID(email)
-		client.Mutex.Unlock()
 		switch err {
 		case nil:
 			l = log.With().
@@ -364,9 +350,7 @@ func resourceUserRead(_ context.Context, d *schema.ResourceData, meta interface{
 	} else {
 		mustSet(d, "status", "registered")
 	}
-	client.Mutex.Lock()
 	currentTeams, err := resourceUserCurrentTeams(c, email, userID, true)
-	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
@@ -399,8 +383,6 @@ func resourceUserDelete(_ context.Context, d *schema.ResourceData, meta interfac
 		Logger()
 	l.Info().Msg("Deleting rollbar_user resource")
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
-	client.Mutex.Lock()
-	setResourceHeader(rollbarUser, c)
 
 	// Try to get user ID
 	userID := d.Get("user_id").(int)
@@ -409,13 +391,11 @@ func resourceUserDelete(_ context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	teamsCurrent, err := resourceUserCurrentTeams(c, email, userID, false)
-	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
 	}
 	teamsExpected := make(map[int]bool) // Empty
-	client.Mutex.Lock()
 	err = resourceUserRemoveTeams(resourceUserAddRemoveTeamsArgs{
 		client:        c,
 		email:         email,
@@ -423,7 +403,6 @@ func resourceUserDelete(_ context.Context, d *schema.ResourceData, meta interfac
 		teamsCurrent:  teamsCurrent,
 		teamsExpected: teamsExpected,
 	})
-	client.Mutex.Unlock()
 	if err != nil {
 		l.Err(err).Send()
 		return diag.FromErr(err)
@@ -457,11 +436,8 @@ func resourceUserImporter(ctx context.Context, d *schema.ResourceData, meta inte
 
 	teamIDs := []int{}
 	c := meta.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
-	client.Mutex.Lock()
-	setResourceHeader(rollbarUser, c)
 
 	invitations, err := c.FindInvitations(email)
-	client.Mutex.Unlock()
 	if err != nil && err != client.ErrNotFound {
 		l.Err(err).Send()
 		return nil, err
@@ -472,9 +448,7 @@ func resourceUserImporter(ctx context.Context, d *schema.ResourceData, meta inte
 	for _, inv := range invitations {
 		teamIDs = append(teamIDs, inv.TeamID)
 	}
-	client.Mutex.Lock()
 	userID, err := c.FindUserID(email)
-	client.Mutex.Unlock()
 	if err == nil {
 		mustSet(d, "user_id", userID)
 		mustSet(d, "status", "registered")


### PR DESCRIPTION
## Description of the change

Removed http headers: X-Rollbar-Terraform-Resource and X-Rollbar-Terraform-DataSource; removed the need of mutex

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

https://rollbar-ext.atlassian.net/browse/ST-18

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
