### PR TITLE
DOP0-722 Added `project_api_key` support for Notification, Integration and Service Link resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Terraform provider for Rollbar
 ==============================
-
+ 
 The Rollbar provider allows Terraform to control resources on
 [Rollbar.com](https://rollbar.com), the Continuous Code Improvement Platform.
 

--- a/rollbar/resource_service_link.go
+++ b/rollbar/resource_service_link.go
@@ -53,6 +53,12 @@ func resourceServiceLink() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"project_api_key": {
+				Description: "Overrides the project_api_key defined in the provider",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+			},
 		},
 	}
 }
@@ -61,12 +67,16 @@ func resourceServiceLinkCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	name := d.Get("name").(string)
 	template := d.Get("template").(string)
+	project_api_key := d.Get("project_api_key").(string)
 
 	l := log.With().Str("name", name).Logger()
 
 	l.Info().Msg("Creating rollbar_service_link resource")
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
+	if len(project_api_key) > 0 {
+		c = client.NewClient(c.BaseURL, project_api_key)
+	}
 
 	client.Mutex.Lock()
 	setResourceHeader(rollbarServiceLink, c)
@@ -91,12 +101,16 @@ func resourceServiceLinkUpdate(ctx context.Context, d *schema.ResourceData, m in
 	id := mustGetID(d)
 	name := d.Get("name").(string)
 	template := d.Get("template").(string)
+	project_api_key := d.Get("project_api_key").(string)
 
 	l := log.With().Str("name", name).Logger()
 
 	l.Info().Msg("Creating rollbar_service_link resource")
 
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
+	if len(project_api_key) > 0 {
+		c = client.NewClient(c.BaseURL, project_api_key)
+	}
 
 	client.Mutex.Lock()
 	setResourceHeader(rollbarServiceLink, c)
@@ -121,12 +135,17 @@ func resourceServiceLinkUpdate(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func resourceServiceLinkRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	project_api_key := d.Get("project_api_key").(string)
 	id := mustGetID(d)
 	l := log.With().
 		Int("id", id).
 		Logger()
 	l.Info().Msg("Reading rollbar_service_link resource")
+
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
+	if len(project_api_key) > 0 {
+		c = client.NewClient(c.BaseURL, project_api_key)
+	}
 
 	client.Mutex.Lock()
 	setResourceHeader(rollbarServiceLink, c)
@@ -150,16 +169,21 @@ func resourceServiceLinkRead(ctx context.Context, d *schema.ResourceData, m inte
 }
 
 func resourceServiceLinkDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	project_api_key := d.Get("project_api_key").(string)
 	id := mustGetID(d)
 	l := log.With().Int("id", id).Logger()
 	l.Info().Msg("Deleting rollbar_service_link resource")
+
 	c := m.(map[string]*client.RollbarAPIClient)[projectKeyToken]
+	if len(project_api_key) > 0 {
+		c = client.NewClient(c.BaseURL, project_api_key)
+	}
 
 	client.Mutex.Lock()
 	setResourceHeader(rollbarServiceLink, c)
 	err := c.DeleteServiceLink(id)
 	client.Mutex.Unlock()
-	
+
 	if err != nil {
 		l.Err(err).Msg("Error deleting rollbar_service_link resource")
 		return diag.FromErr(err)


### PR DESCRIPTION
## Description of the change

This change adds support for an optional new field called `project_api_key` to the Notification, Integration and Service Link resources.  This provides additional flexibility when managing multiple resources from different projects within the same terraform file.  

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
