### PR TITLE
access_token should be marked as a sensitive value.

### DIFF
--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -93,6 +93,7 @@ func resourceProjectAccessToken() *schema.Resource {
 				Description: "Access token for Rollbar API",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 			},
 			"date_created": {
 				Description: "Date the project was created",
@@ -242,7 +243,7 @@ func resourceProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceDat
 	setResourceHeader(rollbarProjectAccessToken, c)
 	err := c.DeleteProjectAccessToken(projectID, accessToken)
 	client.Mutex.Unlock()
-	
+
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
## Description of the change

access_token is not marked as sensitive, and this value is, as if the access_token is leaked while planning, as with this token, people can inject data to rollbar, it should be marked as sensitive to avoid unintentional leaks.

I'm marking as Breaking change , as depending on how the code is used, it may require to call nonsensitive function , but
## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
