### PR TITLE
making project access token sensitive

### DIFF
--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -93,6 +93,7 @@ func resourceProjectAccessToken() *schema.Resource {
 				Description: "Access token for Rollbar API",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 			},
 			"date_created": {
 				Description: "Date the project was created",


### PR DESCRIPTION
## Description of the change

 making project access token sensitive. Notice now access token is not displayed to the user in the terraform _plan_, _apply_ or _destroy_: 

```
 # rollbar_project_access_token.test_1 will be created
  + resource "rollbar_project_access_token" "test_1" {
      + access_token                = (sensitive value)
      + cur_rate_limit_window_count = (known after apply)
      + cur_rate_limit_window_start = (known after apply)
      + date_created                = (known after apply)
      + date_modified               = (known after apply)
      + id                          = (known after apply)
      + name                        = "test-token-1"
      + project_id                  = 222222222222222222
      + rate_limit_window_count     = 500
      + rate_limit_window_size      = 60
      + scopes                      = [
          + "post_client_item",
        ]
      + status                      = "enabled"
    }
```

if the users intentionally want to see a sensitive variable, they can use:
`terraform show --json`
 
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues
relates to PR #384

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
