### PR TITLE
Correct documentation - `terraform import rollbar_user.*` is to be done by email address, not user ID

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -3,7 +3,6 @@
 
 Rollbar user resource.
 
-
 Example Usage
 -------------
 
@@ -27,7 +26,6 @@ The following arguments are supported:
 * `email` - (Required) The user's email address
 * `team_ids` - (Required) IDs of the teams to which this user belongs
 
-
 Attribute Reference
 -------------------
 
@@ -37,12 +35,11 @@ In addition to all arguments above, the following attributes are exported:
 * `user_id` - The ID of the user
 * `status` - Status of the user.  Either `invited` or `subscribed`
 
-
 Import
 ------
 
-Users can be imported using the user ID, e.g.
+Users can be imported using their user email address, e.g.
 
 ```
-$ terraform import rollbar_user.foo 238101
+$ terraform import rollbar_user.some_dev some_dev@company.com
 ```


### PR DESCRIPTION
## Description of the change

This fixes a problem in the documentation around importing existing Rollbar users into `rollbar_user` resources - import _is not_ via user ID - but must be via email address.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

Fixes (part of) issues in:

- #224
- #235

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
