### PR TITLE
added "enabled" field for notification rule

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -118,6 +118,7 @@ jobs:
 
     env:
       ROLLBAR_API_KEY: ${{ secrets.ROLLBAR_API_KEY }}
+      ROLLBAR_PROJECT_API_KEY: ${{ secrets.ROLLBAR_PROJECT_API_KEY }}
 
     steps:
 

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -2,8 +2,6 @@ name: Code Quality Analysis
 
 on:
   push:
-    branches: [ master ]
-    tags: [ v* ]
   pull_request:
   schedule:
     - cron: '0 10 * * 3'
@@ -13,6 +11,11 @@ jobs:
     name: CodeQL
     runs-on: ubuntu-latest
 
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -20,11 +23,6 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Restore cache
     - uses: actions/cache@v2
@@ -37,7 +35,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -48,7 +46,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -62,7 +60,7 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 
   golangci:
     name: golangci-lint

--- a/client/fixtures/notification/create.json
+++ b/client/fixtures/notification/create.json
@@ -2,6 +2,7 @@
   "result": [
     {
       "action": "send_email",
+      "status": "enabled",
       "trigger": "new_item",
       "config": {
         "teams": [

--- a/client/fixtures/notification/read.json
+++ b/client/fixtures/notification/read.json
@@ -2,6 +2,7 @@
   "result": {
     "action": "send_email",
     "trigger": "new_item",
+    "status": "disabled",
     "config": {},
     "id": 5127954,
     "filters": [

--- a/client/fixtures/notification/update.json
+++ b/client/fixtures/notification/update.json
@@ -2,6 +2,7 @@
   "result": {
     "action": "send_email",
     "trigger": "new_item",
+    "status": "disabled",
     "config": {
       "teams": [
         "Owners"

--- a/client/notification.go
+++ b/client/notification.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Rollbar, Inc.
+ * Copyright (c) 2024 Rollbar, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@ import (
 
 type Notification struct {
 	ID      int                    `model:"id" mapstructure:"id"`
+	Status  string                 `model:"status" mapstructure:"status"`
 	Action  string                 `model:"action" mapstructure:"action"`
 	Trigger string                 `model:"trigger" mapstructure:"trigger"`
 	Channel string                 `model:"channel" mapstructure:"channel"`
@@ -39,7 +40,7 @@ type Notification struct {
 }
 
 // CreateNotification creates a new Rollbar notification.
-func (c *RollbarAPIClient) CreateNotification(channel string, filters, trigger, config interface{}) (*Notification, error) {
+func (c *RollbarAPIClient) CreateNotification(channel string, filters, trigger, config interface{}, status string) (*Notification, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	u := c.BaseURL + pathNotificationCreate
@@ -50,7 +51,7 @@ func (c *RollbarAPIClient) CreateNotification(channel string, filters, trigger, 
 	l.Debug().Msg("Creating new notification")
 
 	resp, err := c.Resty.R().
-		SetBody([]map[string]interface{}{{"filters": filters, "trigger": trigger, "config": config}}).
+		SetBody([]map[string]interface{}{{"filters": filters, "trigger": trigger, "config": config, "status": status}}).
 		SetResult(notificationsResponse{}).
 		SetError(ErrorResult{}).
 		Post(u)
@@ -70,7 +71,7 @@ func (c *RollbarAPIClient) CreateNotification(channel string, filters, trigger, 
 }
 
 // UpdateNotification updates a Rollbar notification.
-func (c *RollbarAPIClient) UpdateNotification(notificationID int, channel string, filters, trigger, config interface{}) (*Notification, error) {
+func (c *RollbarAPIClient) UpdateNotification(notificationID int, channel string, filters, trigger, config interface{}, status string) (*Notification, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	u := c.BaseURL + pathNotificationReadOrDeleteOrUpdate
@@ -80,7 +81,7 @@ func (c *RollbarAPIClient) UpdateNotification(notificationID int, channel string
 	l.Debug().Msg("Updating notification")
 
 	resp, err := c.Resty.R().
-		SetBody(map[string]interface{}{"filters": filters, "trigger": trigger, "config": config}).
+		SetBody(map[string]interface{}{"filters": filters, "trigger": trigger, "config": config, "status": status}).
 		SetResult(notificationResponse{}).
 		SetError(ErrorResult{}).
 		SetPathParams(map[string]string{

--- a/client/notification_test.go
+++ b/client/notification_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Rollbar, Inc.
+ * Copyright (c) 2024 Rollbar, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,10 +24,11 @@ package client
 
 import (
 	"encoding/json"
-	"github.com/jarcoal/httpmock"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/jarcoal/httpmock"
 )
 
 // TestCreateNotification tests creating a Rollbar notification.
@@ -38,6 +39,7 @@ func (s *Suite) TestCreateNotification() {
 	u = strings.ReplaceAll(u, "{channel}", channel)
 	action := "send_email"
 	trigger := "new_item"
+	status := "enabled"
 	filters := []map[string]interface{}{}
 	config := map[string]interface{}{}
 
@@ -52,14 +54,15 @@ func (s *Suite) TestCreateNotification() {
 	}
 
 	httpmock.RegisterResponder("POST", u, r)
-	notification, err := s.client.CreateNotification(channel, filters, trigger, config)
+	notification, err := s.client.CreateNotification(channel, filters, trigger, config, status)
 	s.Nil(err)
 	s.Equal(trigger, notification.Trigger)
 	s.Equal(action, notification.Action)
 	s.Equal(id, notification.ID)
+	s.Equal(status, notification.Status)
 
 	s.checkServerErrors("POST", u, func() error {
-		_, err = s.client.CreateNotification(channel, filters, trigger, config)
+		_, err = s.client.CreateNotification(channel, filters, trigger, config, status)
 		return err
 	})
 }
@@ -74,6 +77,7 @@ func (s *Suite) TestUpdateNotification() {
 
 	action := "send_email"
 	trigger := "new_item"
+	status := "disabled"
 	filters := []map[string]interface{}{}
 	config := map[string]interface{}{}
 
@@ -88,14 +92,15 @@ func (s *Suite) TestUpdateNotification() {
 	}
 
 	httpmock.RegisterResponder("PUT", u, r)
-	notification, err := s.client.UpdateNotification(id, channel, filters, trigger, config)
+	notification, err := s.client.UpdateNotification(id, channel, filters, trigger, config, status)
 	s.Nil(err)
 	s.Equal(trigger, notification.Trigger)
 	s.Equal(action, notification.Action)
 	s.Equal(id, notification.ID)
+	s.Equal(status, notification.Status)
 
 	s.checkServerErrors("PUT", u, func() error {
-		_, err = s.client.UpdateNotification(id, channel, filters, trigger, config)
+		_, err = s.client.UpdateNotification(id, channel, filters, trigger, config, status)
 		return err
 	})
 }
@@ -115,6 +120,7 @@ func (s *Suite) TestReadNotification() {
 	n, err := s.client.ReadNotification(id, channel)
 	s.Nil(err)
 	s.Equal("new_item", n.Trigger)
+	s.Equal("disabled", n.Status)
 
 	s.checkServerErrors("GET", u, func() error {
 		_, err := s.client.ReadNotification(id, channel)

--- a/rollbar/test2/resource_integration_test.go
+++ b/rollbar/test2/resource_integration_test.go
@@ -28,7 +28,6 @@ import (
 
 // TestIntegrationCreate tests creating an integration
 func (s *AccSuite) TestIntegrationCreate() {
-	s.T().Skip("unauthorized")
 	integrationResourceName := "rollbar_integration.webhook_integration"
 	// language=hcl
 	config := `
@@ -58,7 +57,6 @@ func (s *AccSuite) TestIntegrationCreate() {
 
 // TestIntegrationUpdate tests updating an integration
 func (s *AccSuite) TestIntegrationUpdate() {
-	s.T().Skip("unauthorized")
 	integrationResourceName := "rollbar_integration.webhook_integration"
 	// language=hcl
 	config1 := `

--- a/rollbar/test2/resource_notification_test.go
+++ b/rollbar/test2/resource_notification_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Rollbar, Inc.
+ * Copyright (c) 2024 Rollbar, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -77,6 +77,57 @@ func (s *AccSuite) TestNotificationCreate() {
 					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.filters.0.type", "environment"),
 					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.filters.1.type", "framework"),
 					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.trigger", "new_item"),
+					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr(notificationResourceName, "config.0.url", "https://www.rollbar.com"),
+					resource.TestCheckResourceAttr(notificationResourceName, "config.0.format", "json"),
+				),
+			},
+		},
+	})
+}
+
+// TestNotificationCreate tests creating a notification
+func (s *AccSuite) TestNotificationCreateDisabledRule() {
+	s.T().Skip("unauthorized")
+	notificationResourceName := "rollbar_notification.webhook_notification"
+	// language=hcl
+	config := `
+		resource "rollbar_notification" "webhook_notification" {
+  rule  {
+	enabled = false
+    filters {
+        type =  "environment"
+        operation =  "eq"
+        value = "production"
+    }
+    filters {
+       type = "framework"
+       operation = "eq"
+       value = 13
+    }
+   trigger = "new_item"
+  }
+  channel = "webhook"
+  config  {
+     url = "https://www.rollbar.com"
+     format = "json"
+  }
+}
+	`
+	resource.ParallelTest(s.T(), resource.TestCase{
+		PreCheck:     func() { s.preCheck() },
+		Providers:    s.providers,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					s.checkResourceStateSanity(notificationResourceName),
+					resource.TestCheckResourceAttr(notificationResourceName, "channel", "webhook"),
+					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.filters.0.type", "environment"),
+					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.filters.1.type", "framework"),
+					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.trigger", "new_item"),
+					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.enabled", "false"),
 					resource.TestCheckResourceAttr(notificationResourceName, "config.0.url", "https://www.rollbar.com"),
 					resource.TestCheckResourceAttr(notificationResourceName, "config.0.format", "json"),
 				),
@@ -93,6 +144,7 @@ func (s *AccSuite) TestNotificationUpdate() {
 	config1 := `
 		resource "rollbar_notification" "webhook_notification" {
   rule  {
+	enabled = true
     filters {
         type =  "environment"
         operation =  "eq"
@@ -115,6 +167,7 @@ func (s *AccSuite) TestNotificationUpdate() {
 	config2 := `
 		resource "rollbar_notification" "webhook_notification" {
   rule  {
+ 	enabled = false
     filters {
         type =  "environment"
         operation =  "eq"
@@ -147,6 +200,7 @@ func (s *AccSuite) TestNotificationUpdate() {
 					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.filters.0.type", "environment"),
 					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.filters.1.type", "framework"),
 					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.trigger", "new_item"),
+					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.enabled", "true"),
 					resource.TestCheckResourceAttr(notificationResourceName, "config.0.url", "https://www.rollbar.com"),
 					resource.TestCheckResourceAttr(notificationResourceName, "config.0.format", "json"),
 				),
@@ -159,6 +213,7 @@ func (s *AccSuite) TestNotificationUpdate() {
 					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.filters.0.type", "environment"),
 					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.filters.1.type", "framework"),
 					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.trigger", "new_item"),
+					resource.TestCheckResourceAttr(notificationResourceName, "rule.0.enabled", "false"),
 					resource.TestCheckResourceAttr(notificationResourceName, "config.0.url", "https://www.rollbar.com"),
 					resource.TestCheckResourceAttr(notificationResourceName, "config.0.format", "xml"),
 				),

--- a/rollbar/test2/resource_notification_test.go
+++ b/rollbar/test2/resource_notification_test.go
@@ -87,7 +87,6 @@ func (s *AccSuite) TestNotificationCreate() {
 
 // TestNotificationCreateDisabledRule tests creating a disbaled notification
 func (s *AccSuite) TestNotificationCreateDisabledRule() {
-	s.T().Skip("unauthorized")
 	notificationResourceName := "rollbar_notification.webhook_notification"
 	// language=hcl
 	config := `
@@ -137,7 +136,6 @@ func (s *AccSuite) TestNotificationCreateDisabledRule() {
 
 // TestNotificationUpdate tests updating a notification
 func (s *AccSuite) TestNotificationUpdate() {
-	s.T().Skip("unauthorized")
 	notificationResourceName := "rollbar_notification.webhook_notification"
 	// language=hcl
 	config1 := `
@@ -222,7 +220,6 @@ func (s *AccSuite) TestNotificationUpdate() {
 }
 
 func (s *AccSuite) TestNotificationCreateSpecialEmail() {
-	s.T().Skip("unauthorized")
 	notificationResourceName := "rollbar_notification.email_notification"
 	// language=hcl
 	config := `

--- a/rollbar/test2/resource_notification_test.go
+++ b/rollbar/test2/resource_notification_test.go
@@ -88,6 +88,7 @@ func (s *AccSuite) TestNotificationCreate() {
 
 // TestNotificationCreateDisabledRule tests creating a disbaled notification
 func (s *AccSuite) TestNotificationCreateDisabledRule() {
+	s.T().Skip("unauthorized")
 	notificationResourceName := "rollbar_notification.webhook_notification"
 	// language=hcl
 	config := `

--- a/rollbar/test2/resource_notification_test.go
+++ b/rollbar/test2/resource_notification_test.go
@@ -39,7 +39,6 @@ func init() {
 
 // TestNotificationCreate tests creating a notification
 func (s *AccSuite) TestNotificationCreate() {
-	s.T().Skip("unauthorized")
 	notificationResourceName := "rollbar_notification.webhook_notification"
 	// language=hcl
 	config := `

--- a/rollbar/test2/resource_notification_test.go
+++ b/rollbar/test2/resource_notification_test.go
@@ -86,9 +86,8 @@ func (s *AccSuite) TestNotificationCreate() {
 	})
 }
 
-// TestNotificationCreate tests creating a notification
+// TestNotificationCreateDisabledRule tests creating a disbaled notification
 func (s *AccSuite) TestNotificationCreateDisabledRule() {
-	s.T().Skip("unauthorized")
 	notificationResourceName := "rollbar_notification.webhook_notification"
 	// language=hcl
 	config := `

--- a/rollbar/test2/resource_service_link_test.go
+++ b/rollbar/test2/resource_service_link_test.go
@@ -40,7 +40,6 @@ func init() {
 
 // TestServiceLinkCreate tests creating a service link
 func (s *AccSuite) TestServiceLinkCreate() {
-	s.T().Skip("unauthorized")
 	serviceLinkResourceName := "rollbar_service_link.service_link"
 	// language=hcl
 	tmpl := `
@@ -70,7 +69,6 @@ func (s *AccSuite) TestServiceLinkCreate() {
 
 // TestServiceLinkUpdate tests updating a service link
 func (s *AccSuite) TestServiceLinkUpdate() {
-	s.T().Skip("unauthorized")
 	serviceLinkResourceName := "rollbar_service_link.service_link"
 	// language=hcl
 	tmpl1 := `


### PR DESCRIPTION
## Description of the change

Added `enabled` boolean field (true/false) for rule notification.
The change is backward compatible; disabled rule (enabled = false) will not be triggered. 

The field is set to true by default. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
