### PR TITLE
sanitize id for project access token resource

### DIFF
--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -156,15 +157,15 @@ func resourceProjectAccessTokenCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	d.SetId(pat.AccessToken)
-
+	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
+	mustSet(d, "access_token", pat.AccessToken)
 	return resourceProjectAccessTokenRead(ctx, d, m)
 }
 
 func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	accessToken := d.Id()
+	accessToken := d.Get("access_token").(string)
 	projectID := d.Get("project_id").(int)
 	l := log.With().
 		Str("accessToken", accessToken).
@@ -195,7 +196,7 @@ func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceProjectAccessTokenUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	accessToken := d.Id()
+	accessToken := d.Get("access_token").(string)
 	projectID := d.Get("project_id").(int)
 	size := d.Get("rate_limit_window_size").(int)
 	count := d.Get("rate_limit_window_count").(int)
@@ -220,7 +221,7 @@ func resourceProjectAccessTokenUpdate(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	accessToken := d.Id()
+	accessToken := d.Get("access_token").(string)
 	projectID := d.Get("project_id").(int)
 
 	l := log.With().
@@ -258,6 +259,7 @@ func resourceProjectAccessTokenImporter(_ context.Context, d *schema.ResourceDat
 		Str("access_token", accessToken).
 		Send()
 	mustSet(d, "project_id", projectID)
-	d.SetId(accessToken)
+	mustSet(d, "access_token", accessToken)
+	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
 	return []*schema.ResourceData{d}, nil
 }

--- a/rollbar/test1/resource_project_access_token_test.go
+++ b/rollbar/test1/resource_project_access_token_test.go
@@ -446,13 +446,13 @@ func (s *AccSuite) TestAccTokenDeleteOnAPIBeforeApply() {
 // properties.
 func (s *AccSuite) checkProjectAccessToken(resourceName string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
-		accessToken, err := s.getResourceIDString(ts, resourceName)
-		if err != nil {
-			return err
-		}
 		rs, ok := ts.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
+		}
+		accessToken := rs.Primary.Attributes["access_token"]
+		if accessToken == "" {
+			return fmt.Errorf("access token is empty")
 		}
 		projectIDString := rs.Primary.Attributes["project_id"]
 		projectID, err := strconv.Atoi(projectIDString)
@@ -506,7 +506,7 @@ func (s *AccSuite) checkProjectAccessToken(resourceName string) resource.TestChe
 // project access token is present in the list of all project access tokens.
 func (s *AccSuite) checkProjectAccessTokenInTokenList(rn string) resource.TestCheckFunc {
 	return func(ts *terraform.State) error {
-		accessToken, err := s.getResourceIDString(ts, rn)
+		accessToken, err := s.getResourceAttrString(ts, rn, "access_token")
 		s.Nil(err)
 		projectID, err := s.getResourceAttrInt(ts, rn, "project_id")
 		s.Nil(err)
@@ -531,7 +531,7 @@ func importIdProjectAccessToken(resourceName string) resource.ImportStateIdFunc 
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
 		projectID := rs.Primary.Attributes["project_id"]
-		accessToken := rs.Primary.ID
+		accessToken := rs.Primary.Attributes["access_token"]
 
 		return fmt.Sprintf("%s/%s", projectID, accessToken), nil
 	}


### PR DESCRIPTION
## Description of the change
terraform ID for a project access token resource was set to access token, which was not really secure causing a leaking token. Now it's sanitized by computing md5 sum on that token. Change was tested, it's backward compatible. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
