### PR TITLE
changing token scopes types to schema.Set

### DIFF
--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -69,7 +69,7 @@ func resourceProjectAccessToken() *schema.Resource {
 			},
 			"scopes": {
 				Description: `List of access scopes granted to the token.  Possible values are "read", "write", "post_server_item", and "post_client_server".`,
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				ForceNew:    true, // FIXME: https://github.com/rollbar/terraform-provider-rollbar/issues/41
@@ -130,9 +130,9 @@ func resourceProjectAccessToken() *schema.Resource {
 func resourceProjectAccessTokenCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	projectID := d.Get("project_id").(int)
 	name := d.Get("name").(string)
-	scopesInterface := d.Get("scopes").([]interface{})
+	scopesInterface := d.Get("scopes").(*schema.Set)
 	scopes := []client.Scope{}
-	for _, v := range scopesInterface {
+	for _, v := range scopesInterface.List() {
 		s := v.(string)
 		scopes = append(scopes, client.Scope(s))
 	}


### PR DESCRIPTION
## Description of the change

changing token scopes types to schema.Set , that way the order of tokens should not matter anymore

In our case it's a safe conversion because we won't have duplicates for scopes. 

related to issue: https://github.com/rollbar/terraform-provider-rollbar/issues/408

Tested locally to make sure it's backward compatible and it's not breaking anything;  functionality is preserved.
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release


## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
