### PR TITLE
Pawel/new project token

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Restore cache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Restore cache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Restore cache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 2
 
     # Restore cache
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v1
 
       - name: Restore Node cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-go@v2
 
       - name: Restore Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Restore cache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Restore cache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod

--- a/client/fixtures/project_access_token/create_with_public_id.json
+++ b/client/fixtures/project_access_token/create_with_public_id.json
@@ -1,0 +1,20 @@
+{
+  "err": 0,
+  "result": {
+    "access_token": "some_access_token",
+    "public_id": "ae9f890512bc4e03ba7084811caa96f8",
+    "cur_rate_limit_window_count": 0,
+    "cur_rate_limit_window_start": 1601987929,
+    "date_created": 1601987929,
+    "date_modified": 1601987929,
+    "name": "foobar",
+    "project_id": 411334,
+    "rate_limit_window_count": null,
+    "rate_limit_window_size": null,
+    "scopes": [
+      "read",
+      "write"
+    ],
+    "status": "enabled"
+  }
+}

--- a/client/project_access_token.go
+++ b/client/project_access_token.go
@@ -34,6 +34,8 @@ type ProjectAccessToken struct {
 	Name                    string  `mapstructure:"name"`
 	ProjectID               int     `json:"project_id" mapstructure:"project_id"`
 	AccessToken             string  `json:"access_token" mapstructure:"access_token"`
+	PublicID                string  `json:"public_id" mapstructure:"public_id"`
+	TokenType               string  `json:"token_type" mapstructure:"token_type"`
 	Scopes                  []Scope `mapstructure:"scopes"`
 	Status                  Status  `mapstructure:"status"`
 	RateLimitWindowSize     int     `json:"rate_limit_window_size" mapstructure:"rate_limit_window_size"`
@@ -62,6 +64,7 @@ type ProjectAccessTokenCreateArgs struct {
 	Name                 string  `json:"name"`
 	Scopes               []Scope `json:"scopes"`
 	Status               Status  `json:"status"`
+	TokenType            string  `json:"token_type"`
 	RateLimitWindowSize  int     `json:"rate_limit_window_size"`
 	RateLimitWindowCount int     `json:"rate_limit_window_count"`
 }
@@ -215,6 +218,12 @@ func (c *RollbarAPIClient) ReadProjectAccessToken(projectID int, token string) (
 
 	for _, t := range tokens {
 		if t.AccessToken == token {
+			l.Debug().
+				Interface("token", t).
+				Msg("Found matching project access token")
+			return t, nil
+		}
+		if t.PublicID == token {
 			l.Debug().
 				Interface("token", t).
 				Msg("Found matching project access token")

--- a/client/project_access_token_test.go
+++ b/client/project_access_token_test.go
@@ -24,11 +24,12 @@ package client
 
 import (
 	"encoding/json"
-	"github.com/jarcoal/httpmock"
-	"github.com/rs/zerolog/log"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/rs/zerolog/log"
 )
 
 // TestListProjectAccessTokens tests listing Rollbar project access tokens.
@@ -290,6 +291,91 @@ func (s *Suite) TestCreateProjectAccessToken() {
 	t, err := s.client.CreateProjectAccessToken(args)
 	s.Nil(err)
 	s.NotEmpty(t.AccessToken)
+	s.Equal(args.Name, t.Name)
+	s.Equal(args.Scopes, t.Scopes)
+	s.Equal(args.ProjectID, t.ProjectID)
+
+	s.checkServerErrors("POST", u, func() error {
+		_, err = s.client.CreateProjectAccessToken(args)
+		return err
+	})
+}
+
+func (s *Suite) TestCreateProjectAccessTokenWithPublicID() {
+	projID := 411334
+
+	args := ProjectAccessTokenCreateArgs{
+		ProjectID: projID,
+		Name:      "foobar",
+		Scopes:    []Scope{ScopeRead, ScopeWrite},
+		Status:    StatusEnabled,
+	}
+	u := s.client.BaseURL + pathProjectTokens
+	u = strings.ReplaceAll(u, "{projectID}", strconv.Itoa(projID))
+	rs := responseFromFixture("project_access_token/create_with_public_id.json", http.StatusOK)
+	r := func(req *http.Request) (*http.Response, error) {
+		a := ProjectAccessTokenCreateArgs{}
+		err := json.NewDecoder(req.Body).Decode(&a)
+		log.Debug().
+			Interface("args", a).
+			Msg("arguments sent to API")
+		s.Nil(err)
+		s.Equal(args.Name, a.Name)
+		s.Equal(args.Scopes, a.Scopes)
+		return rs, nil
+	}
+	httpmock.RegisterResponder("POST", u, r)
+
+	//
+	// Sanity Checks
+	//
+	// Invalid project ID
+	badArgs := args
+	badArgs.ProjectID = 0
+	_, err := s.client.CreateProjectAccessToken(badArgs)
+	s.NotNil(err)
+	badArgs = args
+	badArgs.ProjectID = -234
+	_, err = s.client.CreateProjectAccessToken(badArgs)
+	s.NotNil(err)
+	// Invalid project name
+	badArgs = args
+	badArgs.Name = ""
+	_, err = s.client.CreateProjectAccessToken(badArgs)
+	s.NotNil(err)
+	// No scopes specified
+	badArgs = args
+	badArgs.Scopes = []Scope{}
+	_, err = s.client.CreateProjectAccessToken(badArgs)
+	s.NotNil(err)
+	// Invalid scope
+	badArgs = args
+	derpScope := Scope("derp!")
+	badArgs.Scopes = []Scope{derpScope}
+	_, err = s.client.CreateProjectAccessToken(badArgs)
+	s.NotNil(err)
+	// Invalid status
+	badArgs = args
+	derpStatus := Status("derp!")
+	badArgs.Status = derpStatus
+	_, err = s.client.CreateProjectAccessToken(badArgs)
+	s.NotNil(err)
+	// Invalid rate limit window size
+	badArgs = args
+	badArgs.RateLimitWindowSize = -33
+	_, err = s.client.CreateProjectAccessToken(badArgs)
+	s.NotNil(err)
+	// Invalid rate limit window count
+	badArgs = args
+	badArgs.RateLimitWindowCount = -54
+	_, err = s.client.CreateProjectAccessToken(badArgs)
+	s.NotNil(err)
+
+	// Success
+	t, err := s.client.CreateProjectAccessToken(args)
+	s.Nil(err)
+	s.NotEmpty(t.AccessToken)
+	s.NotEmpty(t.PublicID)
 	s.Equal(args.Name, t.Name)
 	s.Equal(args.Scopes, t.Scopes)
 	s.Equal(args.ProjectID, t.ProjectID)

--- a/rollbar/data_source_project_access_token.go
+++ b/rollbar/data_source_project_access_token.go
@@ -53,7 +53,7 @@ func dataSourceProjectAccessToken() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
-
+			
 			// Computed fields
 			"access_token": {
 				Description: "API token",
@@ -95,6 +95,19 @@ func dataSourceProjectAccessToken() *schema.Resource {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"token_type": {
+				Description: "Access token type for Rollbar API",
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+			},
+			"public_id": {
+				Description: "Public ID for Rollbar API",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   false,
 			},
 			"status": {
 				Description: "Status of the token",

--- a/rollbar/data_source_project_access_tokens.go
+++ b/rollbar/data_source_project_access_tokens.go
@@ -111,6 +111,19 @@ func dataSourceProjectAccessTokens() *schema.Resource {
 							Computed:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
+						"token_type": {
+							Description: "Access token type for Rollbar API",
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+						},
+						"public_id": {
+							Description: "Public ID for Rollbar API",
+							Type:        schema.TypeString,
+							Computed:    true,
+							Sensitive:   false,
+						},
 						"status": {
 							Description: "Status of the token",
 							Type:        schema.TypeString,

--- a/rollbar/data_source_project_access_tokens.go
+++ b/rollbar/data_source_project_access_tokens.go
@@ -90,6 +90,12 @@ func dataSourceProjectAccessTokens() *schema.Resource {
 							Type:        schema.TypeInt,
 							Computed:    true,
 						},
+						"public_id": {
+							Description: "Public ID for Rollbar API",
+							Type:        schema.TypeString,
+							Computed:    true,
+							Sensitive:   false,
+						},
 						"name": {
 							Description: "Name of the token",
 							Type:        schema.TypeString,
@@ -117,12 +123,6 @@ func dataSourceProjectAccessTokens() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							Computed:    true,
-						},
-						"public_id": {
-							Description: "Public ID for Rollbar API",
-							Type:        schema.TypeString,
-							Computed:    true,
-							Sensitive:   false,
 						},
 						"status": {
 							Description: "Status of the token",

--- a/rollbar/resource_project.go
+++ b/rollbar/resource_project.go
@@ -130,7 +130,11 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 			return diag.FromErr(err)
 		}
 		// Deletion
-		err = c.DeleteProjectAccessToken(projectID, t.AccessToken)
+		if t.PublicID != "" {
+			err = c.DeleteProjectAccessToken(projectID, t.PublicID)
+		} else {
+			err = c.DeleteProjectAccessToken(projectID, t.AccessToken)
+		}
 		if err != nil {
 			l.Err(err).Send()
 			return diag.FromErr(err)

--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -80,6 +80,7 @@ func resourceProjectAccessToken() *schema.Resource {
 				Description: "Access token type for Rollbar API",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 				Default:     "legacy",
 			},
 			"status": {

--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -76,6 +76,12 @@ func resourceProjectAccessToken() *schema.Resource {
 			},
 
 			// Optional fields
+			"token_type": {
+				Description: "Access token type for Rollbar API",
+				Type:        schema.TypeString,
+				Optional:    true,
+				//Default:     "v2",
+			},
 			"status": {
 				Description: `Status of the token.  Possible values are "enabled" and "disabled"`,
 				Type:        schema.TypeString,
@@ -102,6 +108,12 @@ func resourceProjectAccessToken() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Sensitive:   true,
+			},
+			"public_id": {
+				Description: "Public ID for Rollbar API",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   false,
 			},
 			"date_created": {
 				Description: "Date the project was created",
@@ -139,6 +151,7 @@ func resourceProjectAccessTokenCreate(ctx context.Context, d *schema.ResourceDat
 	status := client.Status(d.Get("status").(string))
 	size := d.Get("rate_limit_window_size").(int)
 	count := d.Get("rate_limit_window_count").(int)
+	tokenType := d.Get("token_type").(string)
 	l := log.With().
 		Int("project_id", projectID).
 		Str("name", name).
@@ -156,6 +169,7 @@ func resourceProjectAccessTokenCreate(ctx context.Context, d *schema.ResourceDat
 		ProjectID:            projectID,
 		Scopes:               scopes,
 		Status:               status,
+		TokenType:            tokenType,
 		RateLimitWindowSize:  size,
 		RateLimitWindowCount: count,
 	})
@@ -166,6 +180,7 @@ func resourceProjectAccessTokenCreate(ctx context.Context, d *schema.ResourceDat
 
 	d.SetId(getMD5Hash(pat.AccessToken))
 	mustSet(d, "access_token", pat.AccessToken)
+	mustSet(d, "public_id", pat.PublicID)
 	return resourceProjectAccessTokenRead(ctx, d, m)
 }
 
@@ -173,6 +188,11 @@ func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData,
 	var diags diag.Diagnostics
 
 	accessToken := d.Get("access_token").(string)
+	publicID := d.Get("public_id").(string)
+
+	if publicID != "" {
+		accessToken = publicID
+	}
 	projectID := d.Get("project_id").(int)
 	l := log.With().
 		Str("accessToken", accessToken).
@@ -196,6 +216,9 @@ func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData,
 	var mPat map[string]interface{}
 	mustDecodeMapStructure(pat, &mPat)
 	for k, v := range mPat {
+		if k == "access_token" && v == "" { // show access_token in terraform state file
+			continue
+		}
 		mustSet(d, k, v)
 	}
 
@@ -204,6 +227,11 @@ func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData,
 
 func resourceProjectAccessTokenUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	accessToken := d.Get("access_token").(string)
+	publicID := d.Get("public_id").(string)
+
+	if publicID != "" {
+		accessToken = publicID
+	}
 	projectID := d.Get("project_id").(int)
 	size := d.Get("rate_limit_window_size").(int)
 	count := d.Get("rate_limit_window_count").(int)
@@ -230,7 +258,11 @@ func resourceProjectAccessTokenUpdate(ctx context.Context, d *schema.ResourceDat
 func resourceProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	accessToken := d.Get("access_token").(string)
 	projectID := d.Get("project_id").(int)
+	publicID := d.Get("public_id").(string)
 
+	if publicID != "" {
+		accessToken = publicID
+	}
 	l := log.With().
 		Int("projectID", projectID).
 		Str("accessToken", accessToken).

--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -80,7 +80,7 @@ func resourceProjectAccessToken() *schema.Resource {
 				Description: "Access token type for Rollbar API",
 				Type:        schema.TypeString,
 				Optional:    true,
-				//Default:     "v2",
+				Default:     "legacy",
 			},
 			"status": {
 				Description: `Status of the token.  Possible values are "enabled" and "disabled"`,

--- a/rollbar/resource_project_access_token.go
+++ b/rollbar/resource_project_access_token.go
@@ -191,19 +191,21 @@ func resourceProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData,
 	accessToken := d.Get("access_token").(string)
 	publicID := d.Get("public_id").(string)
 
-	if publicID != "" {
-		accessToken = publicID
+	tokenIdentifier := publicID
+	if tokenIdentifier == "" {
+		tokenIdentifier = accessToken
 	}
+
 	projectID := d.Get("project_id").(int)
 	l := log.With().
-		Str("accessToken", accessToken).
+		Str("tokenIdentifier", tokenIdentifier).
 		Logger()
 	l.Debug().Msg("Reading resource project access token")
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 	c.SetHeaderResource(rollbarProjectAccessToken)
 
-	pat, err := c.ReadProjectAccessToken(projectID, accessToken)
+	pat, err := c.ReadProjectAccessToken(projectID, tokenIdentifier)
 
 	if err == client.ErrNotFound {
 		d.SetId("")
@@ -230,15 +232,16 @@ func resourceProjectAccessTokenUpdate(ctx context.Context, d *schema.ResourceDat
 	accessToken := d.Get("access_token").(string)
 	publicID := d.Get("public_id").(string)
 
-	if publicID != "" {
-		accessToken = publicID
+	tokenIdentifier := publicID
+	if tokenIdentifier == "" {
+		tokenIdentifier = accessToken
 	}
 	projectID := d.Get("project_id").(int)
 	size := d.Get("rate_limit_window_size").(int)
 	count := d.Get("rate_limit_window_count").(int)
 	args := client.ProjectAccessTokenUpdateArgs{
 		ProjectID:            projectID,
-		AccessToken:          accessToken,
+		AccessToken:          tokenIdentifier,
 		RateLimitWindowSize:  size,
 		RateLimitWindowCount: count,
 	}
@@ -261,18 +264,19 @@ func resourceProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceDat
 	projectID := d.Get("project_id").(int)
 	publicID := d.Get("public_id").(string)
 
-	if publicID != "" {
-		accessToken = publicID
+	tokenIdentifier := publicID
+	if tokenIdentifier == "" {
+		tokenIdentifier = accessToken
 	}
 	l := log.With().
 		Int("projectID", projectID).
-		Str("accessToken", accessToken).
+		Str("tokenIdentifier", tokenIdentifier).
 		Logger()
 	l.Debug().Msg("Deleting resource project access token")
 
 	c := m.(map[string]*client.RollbarAPIClient)[schemaKeyToken]
 	c.SetHeaderResource(rollbarProjectAccessToken)
-	err := c.DeleteProjectAccessToken(projectID, accessToken)
+	err := c.DeleteProjectAccessToken(projectID, tokenIdentifier)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
## Description of the change

Adding support for token version v2 and v3 (public_id) 

Users will need to download new terraform plugin only when they are enabled for new token and when they want to create new tokens (because API's behavior has changed for new token CREATE ). If the users don’t want to create new tokens, then UPDATE, READ and DELETE will work with old terraform plugin (even when they are enabled for new tokens).

***Note***: we need to set the default value of token_type to `legacy` in order to be backward compatible. That way our users will need to specify token type while creating a new token, which is different from `legacy`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
