### PR TITLE
Add .npmrc ignore-scripts=true (Miasma install-hook mitigation)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
Part of **PLA-1595** (phase 2 of PLA-1580 — Miasma install-hook mitigation).

Adds a repo-local `.npmrc` with `ignore-scripts=true` so dependency lifecycle scripts (`preinstall`/`install`/`postinstall`) do not auto-execute on `npm install` — the execution vector the Miasma / Shai-Hulud worm relies on.

This is the blunt, immediate mitigation applied across the repo fleet. It does **not** stop malware that runs at runtime via normal `import`/`require`. If this repo has a dependency that needs a real build step (native/node-gyp), install/CI may go red — that is expected; triage per repo (allow-list the build, or move to pnpm's default-deny + allow-list model).

PLA-1595
